### PR TITLE
[Server] Feat: 회원가입 구현

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -4,13 +4,13 @@ const cookieParser = require('cookie-parser');
 const app = express();
 const port = process.env.PORT || 3000;
 const mongoose = require('mongoose');
-const { User } = require('./models/user');
-
-const MONGO_URI = process.env.MONGO_URL;
+const { userRouter } = require('./routes');
 
 const server = async () => {
   try {
-    await mongoose.connect(MONGO_URI, {
+    const { MONGO_URL } = process.env;
+    if (!MONGO_URL) throw new Error('MONGO_URL이 필요합니다.');
+    await mongoose.connect(MONGO_URL, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
       useCreateIndex: true,
@@ -22,16 +22,12 @@ const server = async () => {
     app.use(cookieParser());
 
     app.get('/', (req, res) => {
-      res.send('Hello World!');
+      res.send('Hello Server!');
     });
 
-    app.post('/user', async (req, res) => {
-      const user = new User(req.body);
-      await user.save();
-      res.send({ success: true });
-    });
+    app.use('/user', userRouter);
 
-    app.listen(port, () => console.log(`Example app listening at http://localhost:${port}`));
+    app.listen(port, () => console.log(`server listening on port ${port}`));
   } catch (err) {
     console.log(err);
   }

--- a/server/app.js
+++ b/server/app.js
@@ -25,7 +25,7 @@ const server = async () => {
       res.send('Hello Server!');
     });
 
-    app.use('/user', userRouter);
+    app.use('/users', userRouter);
 
     app.listen(port, () => console.log(`server listening on port ${port}`));
   } catch (err) {

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -4,10 +4,14 @@ const {
   Types: { ObjectId },
 } = require('mongoose');
 
+const bcrypt = require('bcrypt');
+const e = require('express');
+let saltRound = 3; //salt를 돌리는 횟수
+
 const userSchema = new Schema(
   {
-    type: { type: String, default: 'user' },
-    email: { type: String, required: true },
+    type: { type: String, default: 'user', enum: ['user', 'admin'] },
+    email: { type: String, required: true, unique: true },
     password: { type: String, required: true },
     nickname: { type: String, required: true, unique: true },
     image_url: String,
@@ -15,6 +19,27 @@ const userSchema = new Schema(
   },
   { timestamps: true },
 );
+
+userSchema.pre('save', function (next) {
+  const user = this;
+
+  if (user.isModified('password')) {
+    bcrypt.genSalt(saltRound, (err, salt) => {
+      if (err) {
+        return next(err);
+      }
+      bcrypt.hash(user.password, salt, (err, hashedPassword) => {
+        if (err) {
+          return next(err);
+        }
+        user.password = hashedPassword;
+        next();
+      });
+    });
+  } else {
+    next();
+  }
+});
 
 const User = model('user', userSchema);
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -5,7 +5,6 @@ const {
 } = require('mongoose');
 
 const bcrypt = require('bcrypt');
-const e = require('express');
 let saltRound = 3; //salt를 돌리는 횟수
 
 const userSchema = new Schema(

--- a/server/package.json
+++ b/server/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "app.js",
   "dependencies": {
+    "bcrypt": "^5.0.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  userRouter: require('./userRoute'),
+};

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -1,0 +1,26 @@
+const { Router } = require('express');
+const userRouter = Router();
+const { User } = require('../models/user');
+
+userRouter.post('/signup', async (req, res) => {
+  try {
+    let { email, password, nickname } = req.body;
+    if (!email) {
+      return res.status(400).send({ message: '이메일을 입력받지 않았습니다.' });
+    }
+    if (!password) {
+      return res.status(400).send({ message: '비밀번호를 입력받지 않았습니다.' });
+    }
+    if (!nickname) {
+      return res.status(400).send({ message: '닉네임을 입력받지 않았습니다.' });
+    }
+    const user = new User(req.body);
+    await user.save();
+    return res.status(201).send({ message: '회원가입이 완료되었습니다.' });
+  } catch (err) {
+    console.log(err);
+    return res.status(500).send({ message: err.message });
+  }
+});
+
+module.exports = userRouter;


### PR DESCRIPTION
1. user Router 생성
2. 회원가입 POST 요청을 보내면 데이터베이스에 입력받은 값을 토대로 생성되게 하였음
3. 기본 이메일, 비밀번호, 닉네임을 입력받게 하였고, body에 어느 하나라도 빠지면 응답 코드 400, 각 경우에 해당하는 에러 메시지를 반환함
4. 닉네임과 이메일은 중복될 경우 DB에 추가되지 않고, 응답코드 500, 에러 메시지를 반환함
4. 비밀번호는 bcrypt를 이용해 해싱한 뒤 데이터베이스에 저장되게 하였음.
- POST 요청이 정상처리 됐을 때
![Screenshot from 2021-09-17 16-55-41](https://user-images.githubusercontent.com/68040092/133746642-4bc92361-0bab-4abd-bf76-986d0877a88b.png)
- 요청이 정상처리 된 후 DB
![Screenshot from 2021-09-17 16-55-55](https://user-images.githubusercontent.com/68040092/133746648-215bfed2-0b30-4aa1-89d5-f43361216eee.png)

