### PR TITLE
[Server] Feat: 로그인 구현

### DIFF
--- a/server/controller/index.js
+++ b/server/controller/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  userController: require('./user'),
+};

--- a/server/controller/user/index.js
+++ b/server/controller/user/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  signup: require('./signup'),
+  signin: require('./signin'),
+};

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -44,7 +44,7 @@ module.exports = {
             sameSite: 'None',
           });
 
-          user.token = refreshToken;
+          user.refreshToken = refreshToken;
           await user.save();
 
           res.status(200).send({ message: 'sign in success' });

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -2,7 +2,7 @@ const { User } = require('../../models/user');
 const { createAccessToken, createRefreshToken } = require('../utils/jwt');
 
 module.exports = {
-  post: async (req, res) => {
+  post: (req, res) => {
     try {
       let { email, password } = req.body;
       if (!email) {

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -1,0 +1,58 @@
+const { User } = require('../../models/user');
+const { createAccessToken, createRefreshToken } = require('../utils/jwt');
+
+module.exports = {
+  post: async (req, res) => {
+    try {
+      let { email, password } = req.body;
+      if (!email) {
+        return res.status(400).send({ message: '이메일을 입력받지 않았습니다.' });
+      }
+      if (!password) {
+        return res.status(400).send({ message: '비밀번호를 입력받지 않았습니다.' });
+      }
+      User.findOne({ email: email }, (err, user) => {
+        if (err) {
+          res.status(400).send(err);
+        }
+
+        if (!user) {
+          return res
+            .status(400)
+            .send({ message: '입력받은 이메일에 해당하는 유저가 존재하지 않습니다.' });
+        }
+
+        user.comparePassword(password, async (err, isMatch) => {
+          if (err) {
+            res.status(400).send(err);
+          }
+
+          if (!isMatch) {
+            return res.status(400).send({ message: '비밀번호가 일치하지 않습니다.' });
+          }
+          const accessToken = createAccessToken(user._id.toHexString());
+          const refreshToken = createRefreshToken({});
+
+          res.cookie('accessToken', accessToken, {
+            httpOnly: true,
+            secure: true,
+            sameSite: 'None',
+          });
+          res.cookie('refreshToken', refreshToken, {
+            httpOnly: true,
+            secure: true,
+            sameSite: 'None',
+          });
+
+          user.token = refreshToken;
+          await user.save();
+
+          res.status(200).send({ message: 'sign in success' });
+        });
+      });
+    } catch (err) {
+      console.log(err);
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/controller/user/signup.js
+++ b/server/controller/user/signup.js
@@ -1,0 +1,24 @@
+const { User } = require('../../models/user');
+
+module.exports = {
+  post: async (req, res) => {
+    try {
+      let { email, password, nickname } = req.body;
+      if (!email) {
+        return res.status(400).send({ message: '이메일을 입력받지 않았습니다.' });
+      }
+      if (!password) {
+        return res.status(400).send({ message: '비밀번호를 입력받지 않았습니다.' });
+      }
+      if (!nickname) {
+        return res.status(400).send({ message: '닉네임을 입력받지 않았습니다.' });
+      }
+      const user = new User(req.body);
+      await user.save();
+      return res.status(201).send({ message: '회원가입이 완료되었습니다.' });
+    } catch (err) {
+      console.log(err);
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/controller/utils/jwt.js
+++ b/server/controller/utils/jwt.js
@@ -1,0 +1,44 @@
+require('dotenv').config();
+const { sign, verify } = require('jsonwebtoken');
+
+module.exports = {
+  createAccessToken(payload) {
+    try {
+      return sign({ payload }, process.env.ACCESS_SECRET, {
+        expiresIn: '3h',
+      });
+    } catch (err) {
+      console.log(err);
+      return null;
+    }
+  },
+  createRefreshToken(payload) {
+    try {
+      return sign(payload, process.env.REFRESH_SECRET, {
+        expiresIn: '14d',
+      });
+    } catch (err) {
+      return null;
+    }
+  },
+  verifyAccessToken(token) {
+    try {
+      if (!token) {
+        return null;
+      }
+      return verify(token, process.env.ACCESS_SECRET);
+    } catch (err) {
+      return null;
+    }
+  },
+  verifyRefreshToken(token) {
+    try {
+      if (!token) {
+        return null;
+      }
+      return verify(token, process.env.REFRESH_SECRET);
+    } catch (err) {
+      return null;
+    }
+  },
+};

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const {
   Schema,
   model,
@@ -14,6 +15,7 @@ const userSchema = new Schema(
     password: { type: String, required: true },
     nickname: { type: String, required: true, unique: true },
     image_url: String,
+    refreshToken: String,
     subscription: { type: ObjectId, ref: 'user' },
   },
   { timestamps: true },
@@ -38,6 +40,15 @@ userSchema.pre('save', function (next) {
   } else {
     next();
   }
+});
+
+userSchema.method('comparePassword', function (plainPassword, callback) {
+  bcrypt.compare(plainPassword, this.password, function (err, isMatch) {
+    if (err) {
+      return callback(err);
+    }
+    callback(null, isMatch);
+  });
 });
 
 const User = model('user', userSchema);

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -1,26 +1,9 @@
 const { Router } = require('express');
 const userRouter = Router();
-const { User } = require('../models/user');
+const { userController } = require('../controller');
 
-userRouter.post('/signup', async (req, res) => {
-  try {
-    let { email, password, nickname } = req.body;
-    if (!email) {
-      return res.status(400).send({ message: '이메일을 입력받지 않았습니다.' });
-    }
-    if (!password) {
-      return res.status(400).send({ message: '비밀번호를 입력받지 않았습니다.' });
-    }
-    if (!nickname) {
-      return res.status(400).send({ message: '닉네임을 입력받지 않았습니다.' });
-    }
-    const user = new User(req.body);
-    await user.save();
-    return res.status(201).send({ message: '회원가입이 완료되었습니다.' });
-  } catch (err) {
-    console.log(err);
-    return res.status(500).send({ message: err.message });
-  }
-});
+userRouter.post('/signup', userController.signup.post);
+
+userRouter.post('/signin', userController.signin.post);
 
 module.exports = userRouter;


### PR DESCRIPTION
- 로그인 관련 구현 부분
1. 이메일, 비밀번호를 입력받아 DB와 비교하여 해당 이메일의 유저가 있을 경우 비밀번호 일치여부 확인
2. 비밀번호가 일치한다면 엑세스토큰, 리프레시토큰을 발급
3. 발급한 두 토큰을 Header의 Set-Cookie에 넣고, 리프레시토큰은 DB에도 저장.
- 그 외 수정 부분
- 하나의 라우팅에 대해 입력 부분이 길어짐에 따라 확인이 어려워, 실제 기능을 controller 폴더를 만들어 분할 시킴

- 로그인 성공했을 때의 Header 부분 Set-Cookie에 두 토큰 추가
![Screenshot from 2021-09-18 14-22-22](https://user-images.githubusercontent.com/68040092/133873793-b553e639-c4c6-4578-9d45-3c1620aa689d.png)
- 로그인 성공했을 때의 DB 하단에 refreshToken 추가
![Screenshot from 2021-09-18 14-22-35](https://user-images.githubusercontent.com/68040092/133873795-5f3bca13-59a9-4594-a67d-a6287a95d979.png)

