### PR TITLE
[Server] Feat: 로그아웃 구현

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const cookieParser = require('cookie-parser');
 const app = express();
+const cors = require('cors');
 const port = process.env.PORT || 3000;
 const mongoose = require('mongoose');
 const { userRouter } = require('./routes');
@@ -14,12 +15,21 @@ const server = async () => {
       useNewUrlParser: true,
       useUnifiedTopology: true,
       useCreateIndex: true,
+      useFindAndModify: false,
     });
     console.log('mongodb connected');
 
     app.use(express.json());
     app.use(express.urlencoded({ extended: true }));
     app.use(cookieParser());
+    app.use(
+      cors({
+        // CORS 설정
+        origin: ['http://localhost', 'https://menuger.shop'],
+        credentials: true,
+        methods: ['GET', 'POST', 'OPTIONS', 'PATCH', 'DELETE'],
+      }),
+    );
 
     app.get('/', (req, res) => {
       res.send('Hello Server!');

--- a/server/controller/user/index.js
+++ b/server/controller/user/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   signup: require('./signup'),
   signin: require('./signin'),
+  signout: require('./signout'),
 };

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -24,7 +24,7 @@ module.exports = {
 
         user.comparePassword(password, async (err, isMatch) => {
           if (err) {
-            res.status(400).send(err);
+            return res.status(400).send(err);
           }
 
           if (!isMatch) {
@@ -35,12 +35,12 @@ module.exports = {
 
           res.cookie('accessToken', accessToken, {
             httpOnly: true,
-            secure: true,
+            secure: false, // 로컬에서 테스트할때는 https로 제공되지 않으므로 false
             sameSite: 'None',
           });
           res.cookie('refreshToken', refreshToken, {
             httpOnly: true,
-            secure: true,
+            secure: false,
             sameSite: 'None',
           });
 

--- a/server/controller/user/signout.js
+++ b/server/controller/user/signout.js
@@ -1,0 +1,34 @@
+const { User } = require('../../models/user');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = {
+  post: (req, res) => {
+    try {
+      const { payload } = verifyAccessToken(req.cookies.accessToken);
+      console.log(payload);
+      if (!payload) {
+        return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+      }
+
+      User.findOneAndUpdate({ _id: ObjectId(payload) }, { refreshToken: '' }, (err, user) => {
+        if (err) {
+          return res.status(400).send(err);
+        }
+        if (!user) {
+          return res.status(400).send({ message: '인증되지 않은 유저입니다.' });
+        }
+
+        return res
+          .clearCookie('accessToken')
+          .clearCookie('refreshToken')
+          .status(200)
+          .send({ message: 'signout success' });
+      });
+    } catch (err) {
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/controller/user/signout.js
+++ b/server/controller/user/signout.js
@@ -8,7 +8,6 @@ module.exports = {
   post: (req, res) => {
     try {
       const { payload } = verifyAccessToken(req.cookies.accessToken);
-      console.log(payload);
       if (!payload) {
         return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
       }

--- a/server/controller/utils/jwt.js
+++ b/server/controller/utils/jwt.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 const { sign, verify } = require('jsonwebtoken');
+const { User } = require('../../models/user');
 
 module.exports = {
   createAccessToken(payload) {
@@ -39,6 +40,60 @@ module.exports = {
       return verify(token, process.env.REFRESH_SECRET);
     } catch (err) {
       return null;
+    }
+  },
+  checkToken(req, res, next) {
+    try {
+      let { accessToken, refreshToken } = req.cookies;
+      if (accessToken === undefined) {
+        throw Error('사용 권한이 없습니다');
+      }
+      const verifiedAccessToken = this.verifyAccessToken(accessToken);
+      const verifiedRefreshToken = this.verifyRefreshToken(refreshToken);
+
+      if (verifiedAccessToken === null) {
+        if (verifiedRefreshToken === null) {
+          // accessToken, refreshToken 모두 만료된 경우
+          throw Error('사용 권한이 없습니다');
+        } else {
+          // accessToken 만료, refreshToken 유효한 경우
+          User.fineOne({ refreshToken }, (err, user) => {
+            if (err) {
+              return res.status(400).send(err);
+            }
+            if (!user) {
+              return res.status(400).send({ message: '인증되지 않은 유저입니다.' });
+            }
+
+            const newAccessToken = this.createAccessToken(user._id.toHexString());
+            res.cookie('accessToken', newAccessToken, {
+              httpOnly: true,
+              secure: true,
+              sameSite: 'None',
+            });
+            accessToken = newAccessToken;
+            next();
+          });
+        }
+      } else {
+        if (verifiedRefreshToken === null) {
+          // accessToken 유효, refreshToken 만료인 경우
+          const newRefreshToken = this.createRefreshToken({});
+          res.cookie('refreshToken', newRefreshToken, {
+            httpOnly: true,
+            secure: true,
+            sameSite: 'None',
+          });
+          refreshToken = newRefreshToken;
+          next();
+        } else {
+          // accessToken, refreshToken 모두 유효한 경우
+          next();
+        }
+      }
+    } catch (err) {
+      console.log(err);
+      return res.status(500).send({ message: err.message });
     }
   },
 };

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -6,4 +6,6 @@ userRouter.post('/signup', userController.signup.post);
 
 userRouter.post('/signin', userController.signin.post);
 
+userRouter.post('/signout', userController.signout.post);
+
 module.exports = userRouter;


### PR DESCRIPTION
##  로그아웃 관련 부분
- /users/signout 라우터 생성
- cookie-parser를 통해 저장되어있는 엑세스토큰을 해독하여 고유 id를 payload로 받고, 해당하는 유저의 db의 refreshToken  필드값을 삭제(초기화)
- cookie에 저장되어있는 엑세스토큰, 리프레시토큰을 clearCookie를 통해 없애줌
- 현재 가지고있는 엑세스토큰을 해독했을 때 고유 id를 받지 못할 경우와, payload로 받은 고유 id의 해당하는 유저가 없을 때를 생각한 엣지케이스 작성

## 로그인 요청을 정상적으로 처리했을 때 엑세스, 리프레시토큰 생성 및 db에 리프레시토큰 값 할당
![Screenshot from 2021-09-19 12-10-09](https://user-images.githubusercontent.com/68040092/133914168-e64b4b92-1fe8-4f49-8d1c-d4856ec9eb92.png)
![Screenshot from 2021-09-19 12-10-28](https://user-images.githubusercontent.com/68040092/133914172-e2c2cb6b-9cc2-4118-8dba-7aca3c5200d8.png)
## 로그아웃 요청을 정상적으로 처리했을 때 토큰 삭제 및 db에 리프레시토큰 값 삭제
![Screenshot from 2021-09-19 12-12-52](https://user-images.githubusercontent.com/68040092/133914218-6ec0ee24-1f7c-47a1-874c-3b8e5a1230c9.png)
![Screenshot from 2021-09-19 12-13-01](https://user-images.githubusercontent.com/68040092/133914225-4e1a7714-cc34-40f2-a350-14e144d4de4d.png)

## 그 외 수정 및 추가 부분
- cors 기본 설정
- mongoose의 findOneAndUpdate 매소드를 쓰기위한 연결 옵션 설정
- 엑세스토큰 및 리프레시토큰을 체크 및 만료된 토큰을 갱신하기 위한 로직 구성
- 현재 http를 통한 테스트를 진행중이어서 signin단계에서 cookie 생성 옵션의 secure:false 값 할당
