### PR TITLE
[Client] Feat: 레시피 작성 페이지 구현

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -15,6 +15,7 @@
 .DS_Store
 .env
 .env.local
+.env.development
 .env.development.local
 .env.test.local
 .env.production.local

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,8 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
+    "@toast-ui/editor-plugin-color-syntax": "^3.0.1",
+    "@toast-ui/react-editor": "^3.1.0",
     "axios": "^0.21.4",
     "dotenv": "^10.0.0",
     "react": "^17.0.2",

--- a/client/src/components/recipe/RecipePost.js
+++ b/client/src/components/recipe/RecipePost.js
@@ -1,0 +1,8 @@
+import { Viewer } from '@toast-ui/react-editor';
+import '@toast-ui/editor/dist/toastui-editor-viewer.css';
+
+const RecipePost = ({ content }) => {
+  return <Viewer initialValue={content} />;
+};
+
+export default RecipePost;

--- a/client/src/components/recipe_edit/ProgressBar.js
+++ b/client/src/components/recipe_edit/ProgressBar.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+const Boundary = styled.div`
+  margin-bottom: 0.5rem;
+  height: 1rem;
+  border-radius: 10px;
+  background-color: #dcdfe1;
+`;
+
+const Progress = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #75b700;
+  height: 1rem;
+  border-radius: 10px;
+  color: white;
+  width: ${({ percent }) => percent}%;
+  transition: 0.5s;
+`;
+
+const ProgressBar = ({ percent }) => {
+  return <Boundary>{!!percent && <Progress percent={percent}>{percent}%</Progress>}</Boundary>;
+};
+
+export default ProgressBar;

--- a/client/src/components/recipe_edit/RecipeEditor.js
+++ b/client/src/components/recipe_edit/RecipeEditor.js
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+import { Editor } from '@toast-ui/react-editor';
+import '@toast-ui/editor/dist/toastui-editor.css';
+import colorSyntax from '@toast-ui/editor-plugin-color-syntax';
+import 'tui-color-picker/dist/tui-color-picker.css';
+import '@toast-ui/editor-plugin-color-syntax/dist/toastui-editor-plugin-color-syntax.css';
+
+import UploadForm from './UploadForm';
+
+const RecipeEditor = ({ editorRef }) => {
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+
+  useEffect(() => {
+    const createImageInsertButton = () => {
+      const btn = document.createElement('button');
+      btn.style.margin = '0';
+      btn.style.backgroundColor = 'transparent';
+      btn.ariaLabel = 'Insert image';
+      btn.innerHTML = '<i>IMG</i>';
+      btn.addEventListener('click', () => setIsUploadingImage(true));
+      return btn;
+    };
+
+    editorRef.current.editorInst.defaultUI.removeToolbarItem('image');
+    editorRef.current.editorInst.defaultUI.insertToolbarItem(
+      { groupIndex: 3, itemIndex: 1 },
+      {
+        name: 'image',
+        el: createImageInsertButton(),
+        tooltip: 'Insert image',
+        style: { backgroundImage: 'none' },
+      },
+    );
+  }, [editorRef]);
+
+  return (
+    <>
+      <Editor
+        initialValue="# 나만의 레시피를 작성해보세요😋"
+        previewStyle="vertical"
+        height="600px"
+        initialEditType="markdown"
+        plugins={[[colorSyntax]]}
+        ref={editorRef}
+      />
+      {isUploadingImage && (
+        <UploadForm editorRef={editorRef} setUploadModal={setIsUploadingImage} />
+      )}
+    </>
+  );
+};
+
+export default RecipeEditor;

--- a/client/src/components/recipe_edit/RecipeEditor.js
+++ b/client/src/components/recipe_edit/RecipeEditor.js
@@ -36,12 +36,12 @@ const RecipeEditor = ({ editorRef }) => {
   return (
     <>
       <Editor
-        initialValue="# 나만의 레시피를 작성해보세요😋"
         previewStyle="vertical"
         height="600px"
         initialEditType="markdown"
         plugins={[[colorSyntax]]}
         ref={editorRef}
+        placeholder="나만의 레시피를 작성해보세요😋"
       />
       {isUploadingImage && (
         <UploadForm editorRef={editorRef} setUploadModal={setIsUploadingImage} />

--- a/client/src/components/recipe_edit/UploadForm.js
+++ b/client/src/components/recipe_edit/UploadForm.js
@@ -1,0 +1,206 @@
+import { useState, useRef } from 'react';
+import styled from 'styled-components';
+import axios from 'axios';
+
+import ProgressBar from './ProgressBar';
+import useKeyPress from '../../hooks/useKeyPress';
+
+const FILE_NUM_LIMIT = 5;
+const PERCENT_TO_RATE_RATIO = 100;
+const FILE_UPLOAD_MESSAGE = '이미지 파일을 업로드 해주세요';
+const TOO_MANY_FILES_MESSAGE = '최대 5개의 이미지 파일만 올려주세요';
+const { REACT_APP_MOBILE_WIDTH, REACT_APP_ENDPOINT_URL } = process.env;
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.3);
+`;
+
+const FormWrapper = styled.div`
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: ${({ width }) => (width ? `${width}%` : '35%')};
+  @media screen and (max-width: ${REACT_APP_MOBILE_WIDTH}) {
+    width: 100%;
+  }
+`;
+
+const Form = styled.form``;
+
+const FileDropper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border: 1px dashed black;
+  min-height: 200px;
+  background-color: #f5f4f5;
+  border-radius: 5px;
+  margin-bottom: 0.5rem;
+  &:hover {
+    background-color: #a4a3a7;
+    transition: 0.3s;
+    color: white;
+  }
+`;
+
+const FileWrapper = styled.div`
+  width: 50%;
+`;
+
+const FileName = styled.div`
+  width: 100%;
+  height: 2rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  text-align: center;
+  font-size: 1.5rem;
+`;
+
+const Input = styled.input`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+`;
+
+const Button = styled.button`
+  display: block;
+  margin-left: auto;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 3px;
+  color: white;
+  background-color: #27ae61;
+  &:hover {
+    background-color: #229954;
+    cursor: pointer;
+  }
+  &:disabled {
+    background-color: gray;
+    cursor: not-allowed;
+  }
+  @media screen and (max-width: ${REACT_APP_MOBILE_WIDTH}) {
+    width: 100%;
+  }
+`;
+
+const UploadForm = ({ editorRef, width, setUploadModal }) => {
+  const marginRef = useRef();
+  const [files, setFiles] = useState(null);
+  const [percents, setPercents] = useState([]);
+  const [uploadedImages, setUploadedImages] = useState(null);
+
+  const closeUploadModal = () => setUploadModal(false);
+  useKeyPress('Escape', closeUploadModal);
+
+  const handleClickMargin = ({ target }) => {
+    if (target === marginRef.current) {
+      closeUploadModal();
+    }
+  };
+
+  const handleImageSelect = ({ target }) => {
+    const fileNum = target.files.length;
+    setUploadedImages(null);
+    if (!fileNum) {
+      return setFiles(null);
+    }
+    if (fileNum > FILE_NUM_LIMIT) {
+      // TODO: replace with custom modal
+      alert(TOO_MANY_FILES_MESSAGE);
+      return setFiles(null);
+    }
+    setFiles(target.files);
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    try {
+      // DELETE: sample code (start)
+      const links = [
+        'https://i.im.ge/2021/09/20/TtmBXL.jpg',
+        'https://i.im.ge/2021/09/20/Ttmv10.jpg',
+      ];
+      const editorInstance = editorRef.current.getInstance();
+      links.forEach(link => editorInstance.insertText(`<img src="${link}" width="200" />\n`));
+      setUploadModal(false);
+      // DELETE (end)
+
+      // TODO: save to S3 then insertText
+      // const presignedData = await axios.post(`${REACT_APP_ENDPOINT_URL}/images/presigned`, {
+      //   contentTypes: [...files].map(file => file.type),
+      // });
+      // await Promise.all(
+      //   [...files].map((file, idx) => {
+      //     const { presigned } = presignedData.data[idx];
+      //     const formData = new FormData();
+      //     for (const key in presigned.fields) {
+      //       formData.append(key, presigned.fields[key]);
+      //     }
+      //     formData.append('Content-Type', file.type);
+      //     formData.append('file', file);
+      //     return axios.post(presigned.url, formData, {
+      //       onUploadProgress: ({ loaded, total }) => {
+      //         setPercents(prevPercents => {
+      //           const newData = [...prevPercents];
+      //           newData[idx] = Math.round((loaded / total) * PERCENT_TO_RATE_RATIO);
+      //           return newData;
+      //         });
+      //       },
+      //     });
+      //   }),
+      // );
+      // const { data: images } = await axios.post(`${REACT_APP_ENDPOINT_URL}/images`, {
+      //   images: [...files].map((file, idx) => ({
+      //     imageKey: presignedData.data[idx].imageKey,
+      //     originalname: file.name,
+      //   })),
+      // });
+      // setUploadedImages(images);
+      // TODO: add alert modal
+    } catch (err) {
+      // TODO: add alert modal
+    }
+  };
+
+  return (
+    <Overlay onClick={handleClickMargin} ref={marginRef}>
+      <FormWrapper width={width}>
+        <Form onSubmit={handleSubmit}>
+          <FileDropper>
+            {files &&
+              [...files].map((file, idx) => (
+                <FileWrapper key={idx}>
+                  <FileName key={file.name}>{file.name}</FileName>
+                  <ProgressBar percent={percents[idx]} />
+                </FileWrapper>
+              ))}
+            {!files && FILE_UPLOAD_MESSAGE}
+            <Input
+              id="image"
+              type="file"
+              multiple
+              accept="image/png, image/jpeg"
+              onChange={handleImageSelect}
+            />
+          </FileDropper>
+          <Button type="submit" disabled={!files || uploadedImages}>
+            URL 변환
+          </Button>
+        </Form>
+      </FormWrapper>
+    </Overlay>
+  );
+};
+
+export default UploadForm;

--- a/client/src/hooks/useKeyPress.js
+++ b/client/src/hooks/useKeyPress.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+const useKeyPress = (key, cb) => {
+  useEffect(() => {
+    const onKeyDown = e => {
+      if (e.key === key) cb();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [key, cb]);
+};
+
+export default useKeyPress;

--- a/client/src/pages/RecipeEditPage.js
+++ b/client/src/pages/RecipeEditPage.js
@@ -1,3 +1,99 @@
-const RecipeEditPage = () => {};
+import { useRef } from 'react';
+import styled from 'styled-components';
+
+import RecipeEditor from '../components/recipe_edit/RecipeEditor';
+import extractThumbnail from '../utils/thumbnail';
+
+const { REACT_APP_MOBILE_WIDTH, REACT_APP_WEB_MAX_WIDTH } = process.env;
+
+const Wrapper = styled.div`
+  margin: 0 auto;
+  max-width: ${REACT_APP_WEB_MAX_WIDTH};
+`;
+
+const RecipeTitleInput = styled.input`
+  border: none;
+  width: 30%;
+  height: 50px;
+  padding-left: 0.5rem;
+  font-size: 1.5rem;
+  margin: 1rem 0;
+  &:focus {
+    padding-top: 2px;
+    outline: none;
+    border-bottom: 1px solid #cdc5bf;
+  }
+  @media screen and (max-width: ${REACT_APP_MOBILE_WIDTH}) {
+    width: 100%;
+  }
+`;
+
+const HashTagInput = styled.input`
+  border: none;
+  width: 100%;
+  height: 30px;
+  padding-left: 0.5rem;
+  margin-top: 0.5rem;
+  font-size: 1rem;
+  &:focus {
+    padding-top: 2px;
+    outline: none;
+    border-bottom: 1px solid #cdc5bf;
+  }
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+`;
+
+const Button = styled.button`
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 3px;
+  color: white;
+  cursor: pointer;
+  &:hover {
+    opacity: 0.8;
+  }
+  @media screen and (max-width: ${REACT_APP_MOBILE_WIDTH}) {
+    width: 100%;
+  }
+`;
+
+//TODO: replace with STANDARD_BUTTON
+const TempSaveBtn = styled(Button)`
+  background-color: #8b8682;
+`;
+//TODO: replace with STANDARD_BUTTON
+const SaveBtn = styled(Button)`
+  margin-left: 0.5rem;
+  background-color: #27ae61;
+`;
+
+const RecipeEditPage = () => {
+  const editorRef = useRef();
+
+  const onClickTempSave = () => {};
+  const onClickSave = () => {
+    const editorInstance = editorRef.current.getInstance();
+    const recipeContent = editorInstance.getHTML();
+    const thumbnail = extractThumbnail(recipeContent);
+    //TODO: save recipeContent and thumbnail
+  };
+
+  return (
+    <Wrapper>
+      <RecipeTitleInput type="text" placeholder="제목" />
+      <RecipeEditor editorRef={editorRef} />
+      <HashTagInput type="text" placeholder="#해시태그" />
+      <Buttons>
+        <TempSaveBtn onClick={onClickTempSave}>임시저장</TempSaveBtn>
+        <SaveBtn onClick={onClickSave}>저장</SaveBtn>
+      </Buttons>
+    </Wrapper>
+  );
+};
 
 export default RecipeEditPage;

--- a/client/src/utils/thumbnail.js
+++ b/client/src/utils/thumbnail.js
@@ -1,0 +1,8 @@
+const extractThumbnail = str => {
+  const regex = /<img.+src=(?:"|')(.+?)(?:"|')(?:.+?)>/;
+  const thumbnail = regex.exec(str);
+
+  return thumbnail ? thumbnail[1] : null;
+};
+
+export default extractThumbnail;


### PR DESCRIPTION
## 작업 내용
- 레시피 작성 페이지
  - toast ui editor 라이브러리 활용
  - 이미지 업로드 customization
  - 첫 번째 이미지 추출 regex 추가
  - 키입력 이벤트 관련 custom hook 추가 
- 레시피 게시물 viewer 컴포넌트
  - toast ui editor 에서 제공하는 viewer 사용

## 작업 상세
- toast ui editor 데모 버젼
![image](https://user-images.githubusercontent.com/38288479/133981851-87aa099f-bb07-4f1a-9037-9f92f1c97c93.png)

데모 버전에서는 이미지 업로드 버튼을 누를 경우 위의 사진처럼 File로 업로드할 지, URL을 추가할지 선택할 수 있다. File로 업로드할 경우 64base 문자열로 변환되어서 게시글 본문에 엄청 긴 텍스트가 추가될 뿐더러, 해당 이미지 데이터를 DB에 저장하기도 까다로워 진다. 사용자가 URL을 통해서 이미지 업로드를 하도록 강요하기 위해서 기존의 이미지 업로드 toolbar를 제거하고, 새로 toolbar menu를 추가.

한 번에 최대 5개의 사진을 고른 후 url로 변환 가능. url로 변환하게 되면 aws S3에 이미지가 저장된다. 게시글 저장버튼을 누르면 게시글 제목, 본문 내용, 작성자 등의 정보가 MongoDB에 저장된다. 현재는 url 변환 버튼을 누를 경우 sample 이미지가 게시글 본문에 추가되도록 설정해놓았다. 이미지 업로드 관련 BE 작업을 선행 한 후에 해당 기능을 마무리할 예정.

## 화면
- 레시피 작성 페이지
![image](https://user-images.githubusercontent.com/38288479/133994550-6b2f3603-7c55-4005-9d47-d4edaee25dd4.png)

- 레시피 작성 페이지(모바일)
![image](https://user-images.githubusercontent.com/38288479/133994741-6dc8a6c8-acaf-43c4-849a-10f733261788.png)

- 레시피 작성 페이지 > 이미지 업로드 모달
![image](https://user-images.githubusercontent.com/38288479/133994863-737ae416-9b02-4656-8677-53ffd658a427.png)

- 레시피 작성 페이지 > 이미지 업로드 모달(모바일)
![image](https://user-images.githubusercontent.com/38288479/133994973-ecd7ae0a-8dbc-483b-a8f3-c72f95c26930.png)