### PR TITLE
[Server] Feat: 유저정보 수정 구현

### DIFF
--- a/server/controller/user/info.js
+++ b/server/controller/user/info.js
@@ -1,24 +1,64 @@
 const { User } = require('../../models/user');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  Types: { ObjectId },
+} = require('mongoose');
 
 module.exports = {
   get: (req, res) => {
-    const { nickname } = req.params;
-    if (!nickname) {
-      res.status(400).send({ message: '닉네임을 입력받지 않았습니다.' });
-    }
-
-    User.findOne({ nickname }, (err, user) => {
-      if (err) {
-        return res.status(400).send(err);
+    try {
+      const { nickname } = req.params;
+      if (!nickname) {
+        res.status(400).send({ message: '닉네임을 입력받지 않았습니다.' });
       }
+
+      User.findOne({ nickname }, (err, user) => {
+        if (err) {
+          return res.status(400).send(err);
+        }
+
+        if (!user) {
+          return res.status(400).send({ message: '존재하지 않는 유저입니다.' });
+        }
+
+        const { email, nickname, image_url = '' } = user;
+
+        res.status(200).send({ nickname, email, image_url });
+      });
+    } catch (err) {
+      console.log(err);
+      return res.status(500).send({ message: err.message });
+    }
+  },
+  patch: async (req, res) => {
+    try {
+      const { payload } = verifyAccessToken(req.cookies.accessToken);
+      if (!payload) {
+        return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+      }
+
+      const user = await User.findById(ObjectId(payload));
 
       if (!user) {
-        return res.status(400).send({ message: '존재하지 않는 유저입니다.' });
+        return res.status(400).send({ message: '인증되지 않은 유저입니다.' });
       }
 
-      const { email, nickname, image_url = '' } = user;
+      const {
+        password = user.password,
+        image_url = user.image_url,
+        nickname = user.nickname,
+      } = req.body;
 
-      res.status(200).send({ nickname, email, image_url });
-    });
+      user.password = password;
+      user.image_url = image_url;
+      user.nickname = nickname;
+
+      await user.save();
+
+      return res.status(200).send({ message: 'modify userinfo success' });
+    } catch (err) {
+      console.log(err);
+      return res.status(500).send({ message: err.message });
+    }
   },
 };

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -12,4 +12,6 @@ userRouter.delete('/', userController.deleteAccount.delete);
 
 userRouter.get('/:nickname', userController.info.get);
 
+userRouter.patch('/', userController.info.patch);
+
 module.exports = userRouter;


### PR DESCRIPTION
## 유저정보 수정 부분
- PATCH users/ 라우터 구현
- request body로 <비밀번호, 이미지url, 닉네임>을 선택적으로 받아 갱신할 수 있게 하였음
- 입력받지 않은 정보들은 현재 유저의 정보를 그대로 기본값으로 두어 갱신할 때 오류가 나지않도록 하였음

## 유저 정보 수정 스크린샷
- 변경 전 유저 정보
![Screenshot from 2021-09-21 10-32-17](https://user-images.githubusercontent.com/68040092/134099099-07dec57a-d3b8-4be0-9321-c9c6f159546a.png)
- 유저 정보 변경 요청(해당 유저로 로그인 하여 쿠키를 가지고 있는 상태)
![Screenshot from 2021-09-21 10-33-40](https://user-images.githubusercontent.com/68040092/134099101-84d61398-a25a-424e-a64f-298d68b84c34.png)
- 변경 된 유저 정보
![Screenshot from 2021-09-21 10-33-53](https://user-images.githubusercontent.com/68040092/134099102-a5f0736a-e884-4c8c-97b8-c2803fb97eba.png)

## 그 외 수정 부분
- GET /users/:nickname 처리 부분(server/info/user/info.js->get)을 try, catch문으로 묶어놓았음.