### PR TITLE
[Server] Feat: 레시피/식단 작성 구현

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -5,7 +5,7 @@ const app = express();
 const cors = require('cors');
 const port = process.env.PORT || 3000;
 const mongoose = require('mongoose');
-const { userRouter } = require('./routes');
+const { userRouter, recipeRouter, dietRouter } = require('./routes');
 
 const server = async () => {
   try {
@@ -36,6 +36,8 @@ const server = async () => {
     });
 
     app.use('/users', userRouter);
+    app.use('/recipes', recipeRouter);
+    app.use('/diets', dietRouter);
 
     app.listen(port, () => console.log(`server listening on port ${port}`));
   } catch (err) {

--- a/server/controller/diet/createPost.js
+++ b/server/controller/diet/createPost.js
@@ -1,0 +1,32 @@
+const { User } = require('../../models/user');
+const { Diet } = require('../../models/diet');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = {
+  post: async (req, res) => {
+    try {
+      const { payload } = verifyAccessToken(req.cookies.accessToken);
+      if (!payload) {
+        return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+      }
+
+      const user = await User.findById(ObjectId(payload));
+      const { title, subtitle, content, hashtag = [] } = req.body;
+
+      const post = new Diet({
+        title,
+        subtitle,
+        content,
+        user,
+        hashtag,
+      });
+      await post.save();
+      return res.status(201).send({ message: '식단 작성이 완료되었습니다.' });
+    } catch (err) {
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/controller/diet/index.js
+++ b/server/controller/diet/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  createPost: require('./createPost'),
+};

--- a/server/controller/index.js
+++ b/server/controller/index.js
@@ -1,3 +1,5 @@
 module.exports = {
   userController: require('./user'),
+  recipeController: require('./recipe'),
+  dietController: require('./diet'),
 };

--- a/server/controller/recipe/createPost.js
+++ b/server/controller/recipe/createPost.js
@@ -1,0 +1,31 @@
+const { User } = require('../../models/user');
+const { Recipe } = require('../../models/recipe');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = {
+  post: async (req, res) => {
+    try {
+      const { payload } = verifyAccessToken(req.cookies.accessToken);
+      if (!payload) {
+        return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+      }
+
+      const user = await User.findById(ObjectId(payload));
+      const { title, content, hashtag = [] } = req.body;
+
+      const post = new Recipe({
+        title,
+        content,
+        user,
+        hashtag,
+      });
+      await post.save();
+      return res.status(201).send({ message: '레시피 작성이 완료되었습니다.' });
+    } catch (err) {
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/controller/recipe/index.js
+++ b/server/controller/recipe/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  createPost: require('./createPost'),
+};

--- a/server/models/diet.js
+++ b/server/models/diet.js
@@ -1,0 +1,31 @@
+const {
+  Schema,
+  model,
+  Types: { ObjectId },
+} = require('mongoose');
+
+const dietSchema = new Schema(
+  {
+    title: { type: String, required: true },
+    subtitle: { type: String, required: true },
+    content: { type: String, required: true },
+    user: { type: ObjectId, ref: 'user', required: true },
+    like_user: { type: ObjectId, ref: 'user' },
+    bookmark_user: { type: ObjectId, ref: 'user' },
+    hashtag: { type: Array, ref: 'hashtag' },
+  },
+  { timestamps: true },
+);
+
+dietSchema.virtual('comments', {
+  ref: 'comment',
+  localField: '_id',
+  foreignField: 'post',
+});
+
+dietSchema.set('toObject', { virtuals: true });
+dietSchema.set('toJSON', { virtuals: true });
+
+const Diet = model('diet', dietSchema);
+
+module.exports = { Diet };

--- a/server/models/recipe.js
+++ b/server/models/recipe.js
@@ -4,30 +4,27 @@ const {
   Types: { ObjectId },
 } = require('mongoose');
 
-const postSchema = new Schema(
+const recipeSchema = new Schema(
   {
     title: { type: String, required: true },
     content: { type: String, required: true },
     user: { type: ObjectId, ref: 'user', required: true },
-    subtitle: String,
-    type: String,
     like_user: { type: ObjectId, ref: 'user' },
     bookmark_user: { type: ObjectId, ref: 'user' },
-
-    hashtag: { type: ObjectId, ref: 'hashtag' },
+    hashtag: { type: Array, ref: 'hashtag' },
   },
   { timestamps: true },
 );
 
-postSchema.virtual('comments', {
+recipeSchema.virtual('comments', {
   ref: 'comment',
   localField: '_id',
   foreignField: 'post',
 });
 
-postSchema.set('toObject', { virtuals: true });
-postSchema.set('toJSON', { virtuals: true });
+recipeSchema.set('toObject', { virtuals: true });
+recipeSchema.set('toJSON', { virtuals: true });
 
-const Post = model('post', postSchema);
+const Recipe = model('recipe', recipeSchema);
 
-module.exports = { Post };
+module.exports = { Recipe };

--- a/server/routes/dietRoute.js
+++ b/server/routes/dietRoute.js
@@ -1,0 +1,7 @@
+const { Router } = require('express');
+const dietRouter = Router();
+const { dietController } = require('../controller');
+
+dietRouter.post('/', dietController.createPost.post);
+
+module.exports = dietRouter;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,3 +1,5 @@
 module.exports = {
   userRouter: require('./userRoute'),
+  recipeRouter: require('./recipeRoute'),
+  dietRouter: require('./dietRoute'),
 };

--- a/server/routes/recipeRoute.js
+++ b/server/routes/recipeRoute.js
@@ -1,0 +1,7 @@
+const { Router } = require('express');
+const recipeRouter = Router();
+const { recipeController } = require('../controller');
+
+recipeRouter.post('/', recipeController.createPost.post);
+
+module.exports = recipeRouter;


### PR DESCRIPTION
## 레시피 작성 구현 부분
- POST recipes/ 라우터 작성
- cookie에 담겨있는 개인정보를 사용하여 유저id는 따로 입력 받지 않고 현재 로그인 한 유저가 작성한 것으로 db에 올라감
- cookie가 없을 때(비 로그인 시)에 작성을 못하도록 조건문을 작성하였음
- request의 body로 제목, 내용, 해시태그(선택)을 입력받아 db에 레시피 저장함

## 식단 작성 구현 부분
- 기본적으로 레시피와 유사하지만, 부제목(subtitle) 필드가 추가되었고, 필수로 입력받도록 하였음.

## 레시피
![Screenshot from 2021-09-21 20-45-52](https://user-images.githubusercontent.com/68040092/134165637-725d75ef-38e6-4bf7-8053-4f487aa5bd4f.png)
![Screenshot from 2021-09-21 20-46-05](https://user-images.githubusercontent.com/68040092/134165640-072ef1ee-c0b6-49ca-a843-37bb0e799d2d.png)
## 식단
![Screenshot from 2021-09-21 20-50-03](https://user-images.githubusercontent.com/68040092/134165679-009d3197-9915-44d7-bdd8-b352542a41b9.png)
![Screenshot from 2021-09-21 20-50-25](https://user-images.githubusercontent.com/68040092/134165699-96b59a7e-753f-4e86-8c08-4698f2a39cfe.png)