### PR TITLE
[Server] Feat: 레시피/식단 조회 구현

### DIFF
--- a/server/controller/diet/index.js
+++ b/server/controller/diet/index.js
@@ -1,3 +1,4 @@
 module.exports = {
   createPost: require('./createPost'),
+  readPost: require('./readPost'),
 };

--- a/server/controller/diet/readPost.js
+++ b/server/controller/diet/readPost.js
@@ -9,7 +9,7 @@ module.exports = {
         res.status(400).send({ message: '해당 id는 유효하지 않습니다.' });
       }
 
-      const diet = await Diet.findOne({ _id: id }).populate([{ path: 'user' }]);
+      const diet = await Diet.findOne({ _id: id });
 
       return res.status(200).send({ diet });
     } catch (err) {

--- a/server/controller/diet/readPost.js
+++ b/server/controller/diet/readPost.js
@@ -1,0 +1,19 @@
+const { Diet } = require('../../models/diet');
+const { isValidObjectId } = require('mongoose');
+
+module.exports = {
+  get: async (req, res) => {
+    try {
+      const { id } = req.params;
+      if (!isValidObjectId(id)) {
+        res.status(400).send({ message: '해당 id는 유효하지 않습니다.' });
+      }
+
+      const diet = await Diet.findOne({ _id: id }).populate([{ path: 'user' }]);
+
+      return res.status(200).send({ diet });
+    } catch (err) {
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/controller/recipe/index.js
+++ b/server/controller/recipe/index.js
@@ -1,3 +1,4 @@
 module.exports = {
   createPost: require('./createPost'),
+  readPost: require('./readPost'),
 };

--- a/server/controller/recipe/readPost.js
+++ b/server/controller/recipe/readPost.js
@@ -1,0 +1,19 @@
+const { Recipe } = require('../../models/recipe');
+const { isValidObjectId } = require('mongoose');
+
+module.exports = {
+  get: async (req, res) => {
+    try {
+      const { id } = req.params;
+      if (!isValidObjectId(id)) {
+        res.status(400).send({ message: '해당 id는 유효하지 않습니다.' });
+      }
+
+      const recipe = await Recipe.findOne({ _id: id }).populate([{ path: 'user' }]);
+
+      return res.status(200).send({ recipe });
+    } catch (err) {
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/controller/recipe/readPost.js
+++ b/server/controller/recipe/readPost.js
@@ -9,7 +9,7 @@ module.exports = {
         res.status(400).send({ message: '해당 id는 유효하지 않습니다.' });
       }
 
-      const recipe = await Recipe.findOne({ _id: id }).populate([{ path: 'user' }]);
+      const recipe = await Recipe.findOne({ _id: id });
 
       return res.status(200).send({ recipe });
     } catch (err) {

--- a/server/models/diet.js
+++ b/server/models/diet.js
@@ -9,7 +9,12 @@ const dietSchema = new Schema(
     title: { type: String, required: true },
     subtitle: { type: String, required: true },
     content: { type: String, required: true },
-    user: { type: ObjectId, ref: 'user', required: true },
+    user: {
+      _id: { type: ObjectId, ref: 'user', required: true },
+      email: { type: String, required: true },
+      nickname: { type: String, required: true },
+      image_url: { type: String, required: true },
+    },
     like_user: { type: ObjectId, ref: 'user' },
     bookmark_user: { type: ObjectId, ref: 'user' },
     hashtag: { type: Array, ref: 'hashtag' },
@@ -17,14 +22,14 @@ const dietSchema = new Schema(
   { timestamps: true },
 );
 
-dietSchema.virtual('comments', {
-  ref: 'comment',
-  localField: '_id',
-  foreignField: 'post',
-});
+// dietSchema.virtual('comments', {
+//   ref: 'comment',
+//   localField: '_id',
+//   foreignField: 'post',
+// });
 
-dietSchema.set('toObject', { virtuals: true });
-dietSchema.set('toJSON', { virtuals: true });
+// dietSchema.set('toObject', { virtuals: true });
+// dietSchema.set('toJSON', { virtuals: true });
 
 const Diet = model('diet', dietSchema);
 

--- a/server/models/recipe.js
+++ b/server/models/recipe.js
@@ -8,7 +8,12 @@ const recipeSchema = new Schema(
   {
     title: { type: String, required: true },
     content: { type: String, required: true },
-    user: { type: ObjectId, ref: 'user', required: true },
+    user: {
+      _id: { type: ObjectId, ref: 'user', required: true },
+      email: { type: String, required: true },
+      nickname: { type: String, required: true },
+      image_url: { type: String, required: true },
+    },
     like_user: { type: ObjectId, ref: 'user' },
     bookmark_user: { type: ObjectId, ref: 'user' },
     hashtag: { type: Array, ref: 'hashtag' },
@@ -16,14 +21,14 @@ const recipeSchema = new Schema(
   { timestamps: true },
 );
 
-recipeSchema.virtual('comments', {
-  ref: 'comment',
-  localField: '_id',
-  foreignField: 'post',
-});
+// recipeSchema.virtual('comments', {
+//   ref: 'comment',
+//   localField: '_id',
+//   foreignField: 'post',
+// });
 
-recipeSchema.set('toObject', { virtuals: true });
-recipeSchema.set('toJSON', { virtuals: true });
+// recipeSchema.set('toObject', { virtuals: true });
+// recipeSchema.set('toJSON', { virtuals: true });
 
 const Recipe = model('recipe', recipeSchema);
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -14,7 +14,7 @@ const userSchema = new Schema(
     email: { type: String, required: true, unique: true },
     password: { type: String, required: true },
     nickname: { type: String, required: true, unique: true },
-    image_url: String,
+    image_url: { type: String, default: 'null' },
     refreshToken: String,
     subscription: { type: ObjectId, ref: 'user' },
   },

--- a/server/routes/dietRoute.js
+++ b/server/routes/dietRoute.js
@@ -4,4 +4,6 @@ const { dietController } = require('../controller');
 
 dietRouter.post('/', dietController.createPost.post);
 
+dietRouter.get('/:id', dietController.readPost.get);
+
 module.exports = dietRouter;

--- a/server/routes/recipeRoute.js
+++ b/server/routes/recipeRoute.js
@@ -4,4 +4,6 @@ const { recipeController } = require('../controller');
 
 recipeRouter.post('/', recipeController.createPost.post);
 
+recipeRouter.get('/:id', recipeController.readPost.get);
+
 module.exports = recipeRouter;


### PR DESCRIPTION
## 레시피/식단 조회 관련 부분
- GET recipes/:id, GET diets/:id 라우터 생성
- 레시피/식단 각 스키마에 유저 정보에서 필요한 부분(이메일, 닉네임, 이미지url)만 내장하였음
=> 개인적인 판단이며, 추후 필요한 필드를 추가 할 수 있음
- 게시물의 id를 파라미터로 받아 조회함

## 레시피 DB
![Screenshot from 2021-09-22 20-16-21](https://user-images.githubusercontent.com/68040092/134336058-bc8575df-8642-4bca-a70a-4d1615e6f4d8.png)
- id를 이용하여 조회했을 때 받는 응답
![Screenshot from 2021-09-22 20-22-37](https://user-images.githubusercontent.com/68040092/134336069-cbf738db-8d42-4a61-a9e0-aace2b12368b.png)

## 그 외
- 레시피/식단 스키마 부분에 댓글용 가상필드 코드를 작성했었는데, 현재는 사용하지 않으므로 주석 처리하였음
=> 댓글 CRUD 구현하는 과정부터 사용할 예정
- 유저 스키마에서 image_url 필드에 'null'(String 타입)을 기본값으로 주었음
=> 게시글 작성 시 해당 유저정보를 내장할 때 해당 필드 값이 null인 경우 오류가 발생했기 때문에 임시 방편으로 넣었음
=> 추후 기본 이미지같은게 있다면 그걸 넣는것도 좋을 것이라 판단됨
