### PR TITLE
[Client] Feat: 해시태그 생성기 추가

### DIFF
--- a/client/src/components/common/HashtagEditor.js
+++ b/client/src/components/common/HashtagEditor.js
@@ -29,6 +29,21 @@ const Tag = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: default;
+  > .delete-btn {
+    background-color: rgba(0, 0, 0, 0);
+    color: #d0d0d0;
+    border: none;
+    cursor: pointer;
+
+    &.delete-btn:hover {
+      color: #ff0000;
+    }
+
+    &.delete-btn:active {
+      color: #bd0000;
+    }
+  }
 `;
 
 const TagInputForm = styled.form`
@@ -55,7 +70,7 @@ const TagInputForm = styled.form`
   }
 */
 
-const HashtagEditor = ({ tagList = [], addTag, width }) => {
+const HashtagEditor = ({ tagList = [], updateTagList, width }) => {
   const [inputTag, setInputTag] = useState('');
   const [placeholderIndex, setPlaceholderIndex] = useState(0);
   const inputBox = useRef();
@@ -66,12 +81,26 @@ const HashtagEditor = ({ tagList = [], addTag, width }) => {
     '한글자 이상 입력해야합니다.',
   ];
 
-  if (typeof addTag !== 'function') {
-    const error = new Error('props로 받은 "addTag"가 함수가 아닙니다. "addTag"는 함수여야 합니다.');
-    addTag = () => {
+  if (typeof updateTagList !== 'function') {
+    const error = new Error(
+      'props로 받은 "updateTagList"가 함수가 아닙니다. "updateTagList"는 함수여야 합니다.',
+    );
+    updateTagList = () => {
       console.error(error);
     };
   }
+
+  const addTag = tag => {
+    const newTagList = [...tagList, tag];
+    updateTagList(newTagList);
+  };
+
+  const removeTag = tag => {
+    const newTagList = tagList.filter(tagInList => {
+      return tagInList.name !== tag.name;
+    });
+    updateTagList(newTagList);
+  };
 
   const focusInputBox = () => {
     inputBox.current.focus();
@@ -111,7 +140,12 @@ const HashtagEditor = ({ tagList = [], addTag, width }) => {
         {tagList.map(tag => {
           return (
             <li key={tag.name}>
-              <Tag>#{tag.name}</Tag>
+              <Tag>
+                #{tag.name}{' '}
+                <button className="delete-btn" onClick={() => removeTag(tag)}>
+                  x
+                </button>
+              </Tag>
             </li>
           );
         })}

--- a/client/src/components/common/HashtagEditor.js
+++ b/client/src/components/common/HashtagEditor.js
@@ -1,0 +1,134 @@
+import styled from 'styled-components';
+import { useState, useRef } from 'react';
+
+const HashtagEditorStyle = styled.div`
+  width: ${props => props.width || 'auto'};
+  border: solid 1px #000;
+  border-radius: 5px;
+  padding: 5px 10px;
+  cursor: text;
+
+  > ul {
+    display: flex;
+    flex-wrap: wrap;
+    align-content: space-around;
+
+    > li {
+      padding: 5px 0;
+      margin-left: 5px;
+    }
+  }
+`;
+
+const Tag = styled.div`
+  height: 100%;
+  font-size: 0.8rem;
+  border: solid 1px #000;
+  border-radius: 5px;
+  padding: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const TagInputForm = styled.form`
+  > input {
+    font-size: 0.8rem;
+    width: 180px;
+    padding: 5px;
+    outline: none;
+    border: ${props => (props.isError ? 'solid 1px #ff0000' : 'solid 1px rgba(0, 0, 0, 0)')};
+    border-radius: 5px;
+  }
+`;
+
+/*
+  props = {
+    tagList:[{
+      id: id,
+      name: tag이름,
+    }],
+    addTag: (tag) => {
+      //tag를 배열에 추가하는 동작
+    },
+    width: 옵션 (기본값=auto),
+  }
+*/
+
+const HashtagEditor = ({ tagList = [], addTag, width }) => {
+  const [inputTag, setInputTag] = useState('');
+  const [placeholderIndex, setPlaceholderIndex] = useState(0);
+  const inputBox = useRef();
+
+  const placeholderList = [
+    '입력 후 enter를 눌러주세요.',
+    '이미 등록된 태그입니다.',
+    '한글자 이상 입력해야합니다.',
+  ];
+
+  if (typeof addTag !== 'function') {
+    const error = new Error('props로 받은 "addTag"가 함수가 아닙니다. "addTag"는 함수여야 합니다.');
+    addTag = () => {
+      console.error(error);
+    };
+  }
+
+  const focusInputBox = () => {
+    inputBox.current.focus();
+  };
+
+  const onChange = e => {
+    if (placeholderIndex !== 0) {
+      setPlaceholderIndex(0);
+    }
+    setInputTag(e.target.value);
+  };
+
+  const onSubmit = e => {
+    e.preventDefault();
+    //입력값 없음
+    if (inputTag.length <= 0) {
+      setPlaceholderIndex(2);
+      return;
+    }
+
+    //중복된 태그
+    const alreadyTag = tagList.find(tag => tag.name === inputTag);
+    if (alreadyTag !== undefined) {
+      setPlaceholderIndex(1);
+      setInputTag('');
+      return;
+    }
+
+    //태그 추가
+    addTag({ id: -1, name: inputTag });
+    setInputTag('');
+  };
+
+  return (
+    <HashtagEditorStyle width={width} onClick={focusInputBox}>
+      <ul>
+        {tagList.map(tag => {
+          return (
+            <li key={tag.name}>
+              <Tag>#{tag.name}</Tag>
+            </li>
+          );
+        })}
+        <li>
+          <TagInputForm onSubmit={onSubmit} isError={placeholderIndex !== 0}>
+            <input
+              type="text"
+              value={inputTag}
+              placeholder={placeholderList[placeholderIndex]}
+              onChange={onChange}
+              ref={inputBox}
+            />
+          </TagInputForm>
+        </li>
+      </ul>
+    </HashtagEditorStyle>
+  );
+};
+
+export default HashtagEditor;

--- a/client/src/pages/DietEditPage.js
+++ b/client/src/pages/DietEditPage.js
@@ -60,10 +60,10 @@ const DietEditPage = () => {
 
   useEffect(() => {
     dispatch(setSelectedContainer(dummyData));
-  }, []);
+  }, [dispatch]);
 
-  const addTag = tag => {
-    setTagList([...tagList, tag]);
+  const updateTagList = tagList => {
+    setTagList(tagList);
   };
   return (
     <DietEditPageStyle>
@@ -71,7 +71,7 @@ const DietEditPage = () => {
       <input id="input-description" type="text" placeholder="식단 소개" />
       <DietColumnContainer columnList={columnList} />
       <textarea style={{ resize: 'none' }} cols="50" rows="10" placeholder="본문" />
-      <HashtagEditor tagList={tagList} addTag={addTag} />
+      <HashtagEditor tagList={tagList} updateTagList={updateTagList} />
       <div className="button-box">
         <StandardButton>임시저장</StandardButton>
         <StandardButton>작성</StandardButton>

--- a/client/src/pages/DietEditPage.js
+++ b/client/src/pages/DietEditPage.js
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
 import { setSelectedContainer } from '../modules/dietColumnContainer';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 //import components
 import DietColumnContainer from '../components/diet/DietColumnContainer';
 import StandardButton from '../components/common/buttons/StandardButton';
+import HashtagEditor from '../components/common/HashtagEditor';
 
 //temporary import
 import dummyData from '../components/diet/dummy_data';
@@ -36,6 +37,7 @@ const DietEditPageStyle = styled.div`
     height: 300px;
     border: solid 1px #000;
     border-radius: 5px;
+    outline: none;
     padding: 10px;
     margin: 10px 0;
   }
@@ -43,6 +45,7 @@ const DietEditPageStyle = styled.div`
   > .button-box {
     display: flex;
     justify-content: right;
+    margin-top: 10px;
 
     button:last-child {
       margin-left: 7px;
@@ -51,21 +54,24 @@ const DietEditPageStyle = styled.div`
 `;
 
 const DietEditPage = () => {
+  const [tagList, setTagList] = useState([]);
   const dispatch = useDispatch();
+  const columnList = useSelector(state => state.dietColumnContainer);
 
   useEffect(() => {
     dispatch(setSelectedContainer(dummyData));
   }, []);
 
-  const columnList = useSelector(state => state.dietColumnContainer);
-
+  const addTag = tag => {
+    setTagList([...tagList, tag]);
+  };
   return (
     <DietEditPageStyle>
       <input id="input-title" type="text" placeholder="제목" />
       <input id="input-description" type="text" placeholder="식단 소개" />
       <DietColumnContainer columnList={columnList} />
       <textarea style={{ resize: 'none' }} cols="50" rows="10" placeholder="본문" />
-      <input placeholder="(임시) ..tag작성" />
+      <HashtagEditor tagList={tagList} addTag={addTag} />
       <div className="button-box">
         <StandardButton>임시저장</StandardButton>
         <StandardButton>작성</StandardButton>


### PR DESCRIPTION
## 해시태그 생성기 추가

## 사용법
```js
<HashtagEditor
  tagList={'태그객체를 요소로 갖는 배열'}
  updateTagList={'부모 컴포넌트의 tag배열 업데이트 함수'}
  width={'폭. 기본값=auto'}
>
```

* tagList=[ { id: -1, name: 'tag name' } , ...];

* updateTagList: 부모컴포넌트에서 tag배열을 수정해주는 함수를 보내주면 됩니다.
  ex)
  ```js
  import HashtagEditor from 'HashtagEditor 경로';
  import { useSatae } from 'react';
  const Parent = () => {
    const [tagList, setTagList] = useState([]);

    const updateTagList = (tagList) => {
      setTagList(tagList);
    }

    return (
      ...
      <HashtagEditor
        tagList={tagList}
        updateTagList={updateTagList}
        width="400px"
      >
    )
  }
  ```

## 사진
* 초기
  ![image](https://user-images.githubusercontent.com/78804014/134444478-a7b5408b-2c31-4a45-9fe8-3d83dc04f159.png)

* 작성
  ![image](https://user-images.githubusercontent.com/78804014/134444556-ce8b0e63-38bd-4c22-bb21-5f571c0414b7.png)

* 중복 작성
  ![image](https://user-images.githubusercontent.com/78804014/134444585-783728a4-d3d9-47af-b558-5460f50c0db4.png)

* 0글자 작성
  ![image](https://user-images.githubusercontent.com/78804014/134444629-f4d11f0b-2a92-41e6-a1f9-bdbef1d9e27e.png)

  

