### PR TITLE
[Server] Feat: 레시피/식단 수정, 삭제 구현

### DIFF
--- a/server/controller/diet/deletePost.js
+++ b/server/controller/diet/deletePost.js
@@ -1,0 +1,33 @@
+const { Diet } = require('../../models/diet');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  isValidObjectId,
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = {
+  delete: async (req, res) => {
+    try {
+      const { payload } = verifyAccessToken(req.cookies.accessToken);
+      if (!payload) {
+        return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+      }
+
+      const { id } = req.params;
+      if (!isValidObjectId(id)) {
+        return res.status(400).send({ message: '해당 게시물id는 유효하지 않습니다.' });
+      }
+
+      const diet = await Diet.findOne({ _id: id });
+
+      if (!diet.user._id.equals(ObjectId(payload))) {
+        return res.status(400).send({ message: '게시물의 작성자만 삭제할 수 있습니다' });
+      }
+
+      await Diet.deleteOne({ _id: id });
+      res.status(200).send({ message: 'delete diet post success' });
+    } catch (err) {
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/controller/diet/index.js
+++ b/server/controller/diet/index.js
@@ -1,4 +1,6 @@
 module.exports = {
   createPost: require('./createPost'),
   readPost: require('./readPost'),
+  updatePost: require('./updatePost'),
+  deletePost: require('./deletePost'),
 };

--- a/server/controller/diet/updatePost.js
+++ b/server/controller/diet/updatePost.js
@@ -1,0 +1,45 @@
+const { Diet } = require('../../models/diet');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  isValidObjectId,
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = {
+  patch: async (req, res) => {
+    try {
+      const { payload } = verifyAccessToken(req.cookies.accessToken);
+      if (!payload) {
+        return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+      }
+
+      const { id } = req.params;
+      if (!isValidObjectId(id)) {
+        return res.status(400).send({ message: '해당 게시물id는 유효하지 않습니다.' });
+      }
+
+      const diet = await Diet.findOne({ _id: id });
+
+      if (!diet.user._id.equals(ObjectId(payload))) {
+        return res.status(400).send({ message: '게시물의 작성자만 수정할 수 있습니다' });
+      }
+
+      const {
+        title = diet.title,
+        subtitle = diet.subtitle,
+        content = diet.content,
+        hashtag = diet.hashtag,
+      } = req.body;
+
+      diet.title = title;
+      diet.subtitle = subtitle;
+      diet.content = content;
+      diet.hashtag = hashtag;
+
+      await diet.save();
+      return res.status(200).send({ message: 'modify diet post success' });
+    } catch (err) {
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/controller/recipe/deletePost.js
+++ b/server/controller/recipe/deletePost.js
@@ -1,0 +1,33 @@
+const { Recipe } = require('../../models/recipe');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  isValidObjectId,
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = {
+  delete: async (req, res) => {
+    try {
+      const { payload } = verifyAccessToken(req.cookies.accessToken);
+      if (!payload) {
+        return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+      }
+
+      const { id } = req.params;
+      if (!isValidObjectId(id)) {
+        return res.status(400).send({ message: '해당 게시물id는 유효하지 않습니다.' });
+      }
+
+      const recipe = await Recipe.findOne({ _id: id });
+
+      if (!recipe.user._id.equals(ObjectId(payload))) {
+        return res.status(400).send({ message: '게시물의 작성자만 삭제할 수 있습니다' });
+      }
+
+      await Recipe.deleteOne({ _id: id });
+      res.status(200).send({ message: 'delete recipe post success' });
+    } catch (err) {
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/controller/recipe/index.js
+++ b/server/controller/recipe/index.js
@@ -1,4 +1,6 @@
 module.exports = {
   createPost: require('./createPost'),
   readPost: require('./readPost'),
+  updatePost: require('./updatePost'),
+  deletePost: require('./deletePost'),
 };

--- a/server/controller/recipe/updatePost.js
+++ b/server/controller/recipe/updatePost.js
@@ -1,0 +1,39 @@
+const { Recipe } = require('../../models/recipe');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  isValidObjectId,
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = {
+  patch: async (req, res) => {
+    try {
+      const { payload } = verifyAccessToken(req.cookies.accessToken);
+      if (!payload) {
+        return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+      }
+
+      const { id } = req.params;
+      if (!isValidObjectId(id)) {
+        return res.status(400).send({ message: '해당 게시물id는 유효하지 않습니다.' });
+      }
+
+      const recipe = await Recipe.findOne({ _id: id });
+
+      if (!recipe.user._id.equals(ObjectId(payload))) {
+        return res.status(400).send({ message: '게시물의 작성자만 수정할 수 있습니다' });
+      }
+
+      const { title = recipe.title, content = recipe.content, hashtag = recipe.hashtag } = req.body;
+
+      recipe.title = title;
+      recipe.content = content;
+      recipe.hashtag = hashtag;
+
+      await recipe.save();
+      return res.status(200).send({ message: 'modify recipe post success' });
+    } catch (err) {
+      return res.status(500).send({ message: err.message });
+    }
+  },
+};

--- a/server/routes/dietRoute.js
+++ b/server/routes/dietRoute.js
@@ -6,4 +6,8 @@ dietRouter.post('/', dietController.createPost.post);
 
 dietRouter.get('/:id', dietController.readPost.get);
 
+dietRouter.patch('/:id', dietController.updatePost.patch);
+
+dietRouter.delete('/:id', dietController.deletePost.delete);
+
 module.exports = dietRouter;

--- a/server/routes/recipeRoute.js
+++ b/server/routes/recipeRoute.js
@@ -6,4 +6,8 @@ recipeRouter.post('/', recipeController.createPost.post);
 
 recipeRouter.get('/:id', recipeController.readPost.get);
 
+recipeRouter.patch('/:id', recipeController.updatePost.patch);
+
+recipeRouter.delete('/:id', recipeController.deletePost.delete);
+
 module.exports = recipeRouter;


### PR DESCRIPTION
## 레시피/식단 수정 부분
- PATCH recipes/:id, PATCH diets/:id 라우터 생성
- 엑세스토큰을 이용해 현재 로그인한 유저 확인 -> 파라미터로 입력받은 게시물id를 이용해 인스턴스 생성 -> 게시물 작성자의 id와 로그인한 유저의 id가 일치하는지 확인
- 선택적으로 입력받은 제목, 부제목(식단 한정), 내용, 해시태그를 인스턴스에 적용 후 저장

## 레시피/식단 삭제 부분
- DELETE recipes/:id, DELETE diets/:id 라우터 생성
- 수정 부분과 확인 절차는 동일
- 파라미터로 입력받은 게시물 id와 동일한 게시물 삭제

## 식단 수정과정
![Screenshot from 2021-09-23 11-19-54](https://user-images.githubusercontent.com/68040092/134451102-680b668d-5f9d-42ef-9d2e-1a9b115679c3.png)
![Screenshot from 2021-09-23 11-26-05](https://user-images.githubusercontent.com/68040092/134451110-ae341867-e10c-421c-b697-7118069cb68e.png)
![Screenshot from 2021-09-23 11-26-18](https://user-images.githubusercontent.com/68040092/134451114-37df1b9a-71a6-4f44-bca6-9163e399ac60.png)
- 게시물의 작성자와 일치하지 않을 때의 처리
![Screenshot from 2021-09-23 11-27-39](https://user-images.githubusercontent.com/68040092/134451130-a5bc2cc8-66c0-4276-8ff3-0b4e2b1b5398.png)
 
## 레시피 삭제과정

![Screenshot from 2021-09-23 12-24-12](https://user-images.githubusercontent.com/68040092/134451191-fb101377-1a17-4c6e-b3db-2143bcd1eae3.png)
![Screenshot from 2021-09-23 12-24-06](https://user-images.githubusercontent.com/68040092/134451186-0c2e5444-fe6b-4c29-8f97-98e6ec2f33f3.png)
![Screenshot from 2021-09-23 12-24-22](https://user-images.githubusercontent.com/68040092/134451200-984a44ed-0fe2-421d-ba6d-2dbdd68a89eb.png)
- 게시물의  작성자와 일치하지 않을 때의 처리
![Screenshot from 2021-09-23 12-23-48](https://user-images.githubusercontent.com/68040092/134451239-47f7bbc9-56cf-4995-bb67-b296f8be6268.png)

