### PR TITLE
[Client] Feat: Modal 컨테이너 구현

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -12,6 +12,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="modal-root"></div>
     <div id="root"></div>
   </body>
 </html>

--- a/client/src/components/common/modal/Modal.js
+++ b/client/src/components/common/modal/Modal.js
@@ -1,0 +1,67 @@
+import ReactDOM from 'react-dom';
+import styled from 'styled-components';
+
+import useKeyPress from '../../../hooks/useKeyPress';
+
+const Overlay = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(1px);
+`;
+
+const ModalContainer = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 100%;
+  max-width: 1130px;
+  height: 90%;
+  margin: auto;
+  padding: 3rem;
+  border-radius: 10px;
+  background: white;
+`;
+
+const CloseBtn = styled.div`
+  position: absolute;
+  top: 0;
+  right: 10px;
+  color: #333333;
+  font-size: 3rem;
+  &:hover {
+    cursor: pointer;
+    color: crimson;
+  }
+`;
+
+const Content = styled.div`
+  height: 100%;
+`;
+
+const Modal = ({ children, hideModal }) => {
+  useKeyPress('Escape', hideModal);
+
+  const modalEl = document.getElementById('modal-root');
+  if (!modalEl) {
+    return null;
+  }
+
+  return ReactDOM.createPortal(
+    <>
+      <Overlay onClick={hideModal} />
+      <ModalContainer>
+        <CloseBtn onClick={hideModal}>&times;</CloseBtn>
+        <Content>{children}</Content>
+      </ModalContainer>
+    </>,
+    modalEl,
+  );
+};
+
+export default Modal;

--- a/client/src/hooks/useModal.js
+++ b/client/src/hooks/useModal.js
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+import Modal from '../components/common/modal/Modal';
+
+const useModal = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const showModal = () => setIsVisible(true);
+  const hideModal = () => setIsVisible(false);
+
+  const ModalContainer = ({ children }) => (
+    <>{isVisible && <Modal hideModal={hideModal}>{children}</Modal>}</>
+  );
+
+  return { isVisible, showModal, hideModal, ModalContainer };
+};
+
+export default useModal;


### PR DESCRIPTION
## 작업 내용
- 재사용 가능한 Modal 컴포넌트 구현
- `게시글(식단/레시피)`이 Modal 안에 위치해야 하므로 가로 너비는 1130px 을 넘지 않는 선에서 최대한으로
- 높이는 화면 높이의 90%로 설정
- 닫기 버튼, 여백을 클릭하거나 ESC를 누르면 Modal 이 사라짐
- createPortal을 활용하여 side-effect를 줄이도록 구현

## 수정 가능한 사항
- overlay 색상, modal 창 너비/높이 등은 useModal() 호출 시 전달받는 props를 반영하도록 수정할 수 있음
- 현재는 styled-component에 명시한 값으로 render 됨

## Usecase
- 레시피/식단 게시글을 click 했을 때 뜨는 Modal로 사용 가능.

## 사용 예시 코드
```js
import useModal from '@hooks/useModal';

const YourComponent = () => {
  const { isVisible, showModal, hideModal, ModalContainer } = useModal();

  return (
    <>
      <button onClick={showModal}>show</button>
      <button onClick={hideModal}>hide</button>

      <ModalContainer>
        <div>게시글 제목</div>
        <div>안녕하세요, 게시글입니다.</div>
      </ModalContainer>
    </>
  );
};

export default YourComponent;
```

## 화면
- web
![image](https://user-images.githubusercontent.com/38288479/134553623-54b7c2a6-8fe6-4b57-98ef-7720670e172b.png)

- mobile
![image](https://user-images.githubusercontent.com/38288479/134553701-206e70a3-ab72-4fa1-9e8e-ea6ad406c269.png)
