### PR TITLE
[Server] Feat: 댓글 작성 구현

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -5,7 +5,7 @@ const app = express();
 const cors = require('cors');
 const port = process.env.PORT || 3000;
 const mongoose = require('mongoose');
-const { userRouter, recipeRouter, dietRouter } = require('./routes');
+const { userRouter, recipeRouter, dietRouter, commentRouter } = require('./routes');
 
 const server = async () => {
   try {
@@ -38,6 +38,7 @@ const server = async () => {
     app.use('/users', userRouter);
     app.use('/recipes', recipeRouter);
     app.use('/diets', dietRouter);
+    app.use('/:postType/:postId/comments', commentRouter);
 
     app.listen(port, () => console.log(`server listening on port ${port}`));
   } catch (err) {

--- a/server/controller/comment/createComment.js
+++ b/server/controller/comment/createComment.js
@@ -1,0 +1,51 @@
+const { User } = require('../../models/user');
+const { Diet } = require('../../models/diet');
+const { Recipe } = require('../../models/recipe');
+const { Comment } = require('../../models/comment');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  isValidObjectId,
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = async (req, res) => {
+  try {
+    const { payload } = verifyAccessToken(req.cookies.accessToken);
+    if (!payload) {
+      return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+    }
+
+    const { postType, postId } = req.params;
+    const { content } = req.body;
+    if (!(postType === 'recipes' || postType === 'diets')) {
+      return res.status(400).send({ message: '올바른 게시물 타입이 아닙니다.' });
+    }
+    if (!isValidObjectId(postId)) {
+      return res.status(400).send({ message: '해당 게시물id는 유효하지 않습니다.' });
+    }
+    if (typeof content !== 'string') {
+      return res.status(400).send({ message: '댓글 내용을 입력받지 않았습니다.' });
+    }
+
+    const user = await User.findById(ObjectId(payload));
+    if (!user) {
+      return res.status(400).send({ message: '존재하지 않는 유저입니다.' });
+    }
+    let post;
+    if (postType === 'recipes') {
+      post = await Recipe.findById(ObjectId(postId));
+    } else {
+      post = await Diet.findById(ObjectId(postId));
+    }
+
+    if (!post) {
+      return res.status(400).send({ message: '존재하지 않는 게시물입니다.' });
+    }
+
+    const comment = new Comment({ content, user, post });
+    await comment.save();
+    return res.status(200).send({ message: '댓글이 작성되었습니다.' });
+  } catch (err) {
+    return res.status(500).send({ message: err.message });
+  }
+};

--- a/server/controller/comment/index.js
+++ b/server/controller/comment/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  createComment: require('./createComment'),
+};

--- a/server/controller/index.js
+++ b/server/controller/index.js
@@ -2,4 +2,5 @@ module.exports = {
   userController: require('./user'),
   recipeController: require('./recipe'),
   dietController: require('./diet'),
+  commentController: require('./comment'),
 };

--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -7,8 +7,26 @@ const {
 const commentSchema = new Schema(
   {
     content: { type: String, required: true },
-    user: { type: ObjectId, ref: 'user' },
-    post: { type: ObjectId, ref: 'post' },
+    user: {
+      _id: { type: ObjectId, ref: 'user', required: true },
+      email: { type: String, required: true },
+      nickname: { type: String, required: true },
+      image_url: { type: String, required: true },
+    },
+    post: {
+      _id: { type: ObjectId, required: true, refPath: 'postType' },
+      user: {
+        _id: { type: ObjectId, ref: 'user', required: true },
+        email: { type: String, required: true },
+        nickname: { type: String, required: true },
+        image_url: { type: String, required: true },
+      },
+      hashtag: { type: Array, required: true, ref: 'hashtag' },
+      title: { type: String, required: true },
+      subtitle: String,
+      content: { type: String, required: true },
+    },
+    postType: { type: String, enum: ['recipe', 'diet'] },
   },
   { timestamps: true },
 );

--- a/server/routes/commentRoute.js
+++ b/server/routes/commentRoute.js
@@ -1,0 +1,7 @@
+const { Router } = require('express');
+const commentRouter = Router({ mergeParams: true });
+const { commentController } = require('../controller');
+
+commentRouter.post('/', commentController.createComment);
+
+module.exports = commentRouter;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,4 +2,5 @@ module.exports = {
   userRouter: require('./userRoute'),
   recipeRouter: require('./recipeRoute'),
   dietRouter: require('./dietRoute'),
+  commentRouter: require('./commentRoute'),
 };


### PR DESCRIPTION
## 댓글 작성 구현 부분
- POST /:postType/:postId/comments 라우터 생성
=> 댓글을 따로 다는게 아니라 레시피 혹은 식단 포스팅에만 달 수 있다고 생각하여 이와같이 라우팅을 구성하였음
- 로그인 한 유저만 댓글을 작성할 수 있게 하였음
- postType 파라미터로 recipes 또는 diets를 받고, 해당 파라미터를 토대로 게시글을 찾도록 하였음
- 댓글 스키마에 필요하다고 생각하는 부분인 댓글 내용, 작성 유저, 게시글 정보를 내장하였음

## 댓글 작성 요청
![Screenshot from 2021-09-24 12-25-06](https://user-images.githubusercontent.com/68040092/134613474-0bbfde23-e070-4435-8cec-c8a4e5310661.png)
## 정상적으로 처리된 후의 데이터베이스
![Screenshot from 2021-09-24 12-20-18](https://user-images.githubusercontent.com/68040092/134613321-564e72b0-8055-4fdf-bf20-fafdaa4d3aed.png)
 