### PR TITLE
[Server] Feat: 댓글 수정/삭제 구현

### DIFF
--- a/server/controller/comment/deleteComment.js
+++ b/server/controller/comment/deleteComment.js
@@ -1,0 +1,34 @@
+const { Comment } = require('../../models/comment');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  isValidObjectId,
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = async (req, res) => {
+  try {
+    const { payload } = verifyAccessToken(req.cookies.accessToken);
+    if (!payload) {
+      return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+    }
+
+    const { commentId } = req.params;
+    if (!isValidObjectId(commentId)) {
+      return res.status(400).send({ message: '해당 댓글id는 유효하지 않습니다.' });
+    }
+
+    const comment = await Comment.findById(ObjectId(commentId));
+    if (!comment) {
+      return res.status(400).send({ message: '존재하지 않는 댓글입니다.' });
+    }
+
+    if (!comment.user._id.equals(ObjectId(payload))) {
+      return res.status(400).send({ message: '댓글 작성자만 삭제할 수 있습니다.' });
+    }
+
+    await Comment.deleteOne({ _id: commentId });
+    return res.status(200).send({ message: 'delete comment success' });
+  } catch (err) {
+    return res.status(500).send({ message: err.message });
+  }
+};

--- a/server/controller/comment/index.js
+++ b/server/controller/comment/index.js
@@ -1,3 +1,5 @@
 module.exports = {
   createComment: require('./createComment'),
+  deleteComment: require('./deleteComment'),
+  updateComment: require('./updateComment'),
 };

--- a/server/controller/comment/updateComment.js
+++ b/server/controller/comment/updateComment.js
@@ -1,0 +1,41 @@
+const { Comment } = require('../../models/comment');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  isValidObjectId,
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = async (req, res) => {
+  try {
+    const { payload } = verifyAccessToken(req.cookies.accessToken);
+    if (!payload) {
+      return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+    }
+
+    const { commentId } = req.params;
+    if (!isValidObjectId(commentId)) {
+      return res.status(400).send({ message: '해당 댓글id는 유효하지 않습니다.' });
+    }
+
+    const comment = await Comment.findById(ObjectId(commentId));
+    if (!comment) {
+      return res.status(400).send({ message: '존재하지 않는 댓글입니다.' });
+    }
+
+    if (!comment.user._id.equals(ObjectId(payload))) {
+      return res.status(400).send({ message: '댓글 작성자만 수정할 수 있습니다.' });
+    }
+
+    const { content } = req.body;
+    if (typeof content !== 'string') {
+      return res.status(400).send({ message: '댓글의 수정할 내용을 입력해주세요.' });
+    }
+
+    comment.content = content;
+    await comment.save();
+
+    return res.status(200).send({ message: 'modify comment success' });
+  } catch (err) {
+    return res.status(500).send({ message: err.message });
+  }
+};

--- a/server/routes/commentRoute.js
+++ b/server/routes/commentRoute.js
@@ -4,4 +4,8 @@ const { commentController } = require('../controller');
 
 commentRouter.post('/', commentController.createComment);
 
+commentRouter.delete('/:commentId', commentController.deleteComment);
+
+commentRouter.patch('/:commentId', commentController.updateComment);
+
 module.exports = commentRouter;


### PR DESCRIPTION
## 댓글 수정/삭제 구현
- PATCH&DELETE /:postType/:postId/comments/:commentId 라우팅 구현
### 공통 부분
- 유저의 로그인 상태 검사
- 댓글 id의 유효성 검사 및 댓글이 db에 존재하는지 검사
- 댓글을 등록한 유저의 id와 댓글을 수정/삭제 하려는 유저가 동일한지 검사
### 댓글 수정 부분
- request의 body로 content를 입력받았는지를 검사한 뒤, 해당 내용을 db에 반영
### 댓글 삭제 부분
- 파라미터로 받은 댓글 id와 일치하는 댓글을 삭제

## 댓글 수정 요청
![Screenshot from 2021-09-24 17-02-12](https://user-images.githubusercontent.com/68040092/134640938-76b1ab86-aac8-44f3-9ea4-24f8c50f1342.png)
![Screenshot from 2021-09-24 17-02-28](https://user-images.githubusercontent.com/68040092/134640941-c47f73c0-9182-419a-9cce-a10d130711d3.png)
![Screenshot from 2021-09-24 17-02-39](https://user-images.githubusercontent.com/68040092/134640944-f245cf09-7d76-4a52-b083-a0c6fc62b5ff.png)

## 댓글 삭제 요청
![Screenshot from 2021-09-24 16-46-23](https://user-images.githubusercontent.com/68040092/134640846-7dd2e12c-1bb7-4f5b-9818-b87387f7d862.png)
![Screenshot from 2021-09-24 16-48-26](https://user-images.githubusercontent.com/68040092/134640877-d0d709b9-724c-46b2-972a-ee6dba411cfd.png)

