### PR TITLE
[Server] Fix: 게시물 스키마, 댓글 CRUD 부분 코드수정

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -17,6 +17,7 @@ const server = async () => {
       useCreateIndex: true,
       useFindAndModify: false,
     });
+    mongoose.set('debug', true); // mongodb 쿼리문 디버깅 확인용 코드
     console.log('mongodb connected');
 
     app.use(express.json());

--- a/server/controller/comment/deleteComment.js
+++ b/server/controller/comment/deleteComment.js
@@ -1,4 +1,6 @@
 const { Comment } = require('../../models/comment');
+const { Diet } = require('../../models/diet');
+const { Recipe } = require('../../models/recipe');
 const { verifyAccessToken } = require('../utils/jwt');
 const {
   isValidObjectId,
@@ -12,7 +14,7 @@ module.exports = async (req, res) => {
       return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
     }
 
-    const { commentId } = req.params;
+    const { postType, commentId } = req.params;
     if (!isValidObjectId(commentId)) {
       return res.status(400).send({ message: '해당 댓글id는 유효하지 않습니다.' });
     }
@@ -25,8 +27,23 @@ module.exports = async (req, res) => {
     if (!comment.user._id.equals(ObjectId(payload))) {
       return res.status(400).send({ message: '댓글 작성자만 삭제할 수 있습니다.' });
     }
-
-    await Comment.deleteOne({ _id: commentId });
+    if (postType === 'recipes') {
+      await Promise.all([
+        Comment.deleteOne({ _id: ObjectId(commentId) }),
+        Recipe.updateOne(
+          { 'comments._id': ObjectId(commentId) },
+          { $pull: { comments: { _id: commentId } } },
+        ),
+      ]);
+    } else {
+      await Promise.all([
+        Comment.deleteOne({ _id: ObjectId(commentId) }),
+        Diet.updateOne(
+          { 'comments._id': ObjectId(commentId) },
+          { $pull: { comments: { _id: commentId } } },
+        ),
+      ]);
+    }
     return res.status(200).send({ message: 'delete comment success' });
   } catch (err) {
     return res.status(500).send({ message: err.message });

--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -13,24 +13,11 @@ const commentSchema = new Schema(
       nickname: { type: String, required: true },
       image_url: { type: String, required: true },
     },
-    post: {
-      _id: { type: ObjectId, required: true, refPath: 'postType' },
-      user: {
-        _id: { type: ObjectId, ref: 'user', required: true },
-        email: { type: String, required: true },
-        nickname: { type: String, required: true },
-        image_url: { type: String, required: true },
-      },
-      hashtag: { type: Array, required: true, ref: 'hashtag' },
-      title: { type: String, required: true },
-      subtitle: String,
-      content: { type: String, required: true },
-    },
-    postType: { type: String, enum: ['recipe', 'diet'] },
+    // postType: { type: String, enum: ['recipes', 'diets'] },
   },
   { timestamps: true },
 );
 
 const Comment = model('comment', commentSchema);
 
-module.exports = { Comment };
+module.exports = { Comment, commentSchema };

--- a/server/models/diet.js
+++ b/server/models/diet.js
@@ -3,6 +3,7 @@ const {
   model,
   Types: { ObjectId },
 } = require('mongoose');
+const { commentSchema } = require('./comment');
 
 const dietSchema = new Schema(
   {
@@ -15,6 +16,7 @@ const dietSchema = new Schema(
       nickname: { type: String, required: true },
       image_url: { type: String, required: true },
     },
+    comments: [commentSchema],
     like_user: { type: ObjectId, ref: 'user' },
     bookmark_user: { type: ObjectId, ref: 'user' },
     hashtag: { type: Array, ref: 'hashtag' },

--- a/server/models/diet.js
+++ b/server/models/diet.js
@@ -24,15 +24,6 @@ const dietSchema = new Schema(
   { timestamps: true },
 );
 
-// dietSchema.virtual('comments', {
-//   ref: 'comment',
-//   localField: '_id',
-//   foreignField: 'post',
-// });
-
-// dietSchema.set('toObject', { virtuals: true });
-// dietSchema.set('toJSON', { virtuals: true });
-
 const Diet = model('diet', dietSchema);
 
 module.exports = { Diet };

--- a/server/models/recipe.js
+++ b/server/models/recipe.js
@@ -3,6 +3,7 @@ const {
   model,
   Types: { ObjectId },
 } = require('mongoose');
+const { commentSchema } = require('./comment');
 
 const recipeSchema = new Schema(
   {
@@ -14,6 +15,7 @@ const recipeSchema = new Schema(
       nickname: { type: String, required: true },
       image_url: { type: String, required: true },
     },
+    comments: [commentSchema],
     like_user: { type: ObjectId, ref: 'user' },
     bookmark_user: { type: ObjectId, ref: 'user' },
     hashtag: { type: Array, ref: 'hashtag' },
@@ -24,7 +26,7 @@ const recipeSchema = new Schema(
 // recipeSchema.virtual('comments', {
 //   ref: 'comment',
 //   localField: '_id',
-//   foreignField: 'post',
+//   foreignField: 'post._id',
 // });
 
 // recipeSchema.set('toObject', { virtuals: true });

--- a/server/models/recipe.js
+++ b/server/models/recipe.js
@@ -23,15 +23,6 @@ const recipeSchema = new Schema(
   { timestamps: true },
 );
 
-// recipeSchema.virtual('comments', {
-//   ref: 'comment',
-//   localField: '_id',
-//   foreignField: 'post._id',
-// });
-
-// recipeSchema.set('toObject', { virtuals: true });
-// recipeSchema.set('toJSON', { virtuals: true });
-
 const Recipe = model('recipe', recipeSchema);
 
 module.exports = { Recipe };


### PR DESCRIPTION
## 게시물(레시피/식단) 스키마 수정 부분
- 코멘트들을 배열형태로 담아서 볼 수 있게 추가하였음

## 댓글 CRUD 부분
- 댓글 작성 시, 코멘트 콜렉션에도 데이터가 추가 되지만, 해당하는 게시물에도 댓글이 추가되어 게시글 확인 요청 시 댓글들도 받아볼 수 있도록 하였음
=> 댓글 수가 많아질 경우 처리가 무거워질 수 있으므로 페이지네이션처럼 최근 작성한 댓글 N개만 받아오게끔 하는 처리가 필요하지 않을까 생각됨

## GET 요청으로 식단 하나를 불러왔을 때의 응답
![Screenshot from 2021-09-25 14-14-41](https://user-images.githubusercontent.com/68040092/134759473-ec206f91-d866-4039-96fe-afe2397ef90a.png)
