### PR TITLE
[Client] Feat: 구독 버튼 컴포넌트 구현

### DIFF
--- a/client/src/components/common/buttons/SubscribeButton.js
+++ b/client/src/components/common/buttons/SubscribeButton.js
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+import ButtonSpinner from '../spinners/ButtonSpinner';
+
+const SubBtn = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  width: 8em;
+  height: 2.1em;
+  color: ${({ subscribed }) => (subscribed ? '#646060' : 'white')};
+  background-color: ${({ subscribed }) => (subscribed ? '#ececec' : '#cc0000')};
+  border-radius: 3px;
+  font-size: ${({ fontSize }) => `${fontSize}px`};
+  font-weight: bold;
+  &:hover {
+    cursor: pointer;
+  }
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;
+
+const SubscribeButton = ({ subscribed, toggle, loading, fontSize }) => {
+  const spinnerWidth = fontSize * 1.5;
+
+  return (
+    <SubBtn subscribed={subscribed} onClick={toggle} fontSize={fontSize} disabled={loading}>
+      {loading && <ButtonSpinner width={spinnerWidth} />}
+      {!loading && (subscribed ? 'SUBSCRIBED' : 'SUBSCRIBE')}
+    </SubBtn>
+  );
+};
+
+export default SubscribeButton;

--- a/client/src/components/common/spinners/ButtonSpinner.js
+++ b/client/src/components/common/spinners/ButtonSpinner.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Spinner = styled.svg`
+  animation: rotate 2s linear infinite;
+  width: ${({ width }) => (width ? `${width}px` : '15px')};
+  height: ${({ width }) => (width ? `${width}px` : '15px')};
+  & .path {
+    stroke: #5652bf;
+    stroke-linecap: round;
+    animation: dash 1.5s ease-in-out infinite;
+  }
+
+  @keyframes rotate {
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes dash {
+    0% {
+      stroke-dasharray: 1, 150;
+      stroke-dashoffset: 0;
+    }
+    50% {
+      stroke-dasharray: 90, 150;
+      stroke-dashoffset: -35;
+    }
+    100% {
+      stroke-dasharray: 90, 150;
+      stroke-dashoffset: -124;
+    }
+  }
+`;
+
+const ButtonSpinner = ({ width }) => (
+  <Spinner viewBox="0 0 50 50" width={width}>
+    <circle className="path" cx="25" cy="25" r="20" fill="none" strokeWidth="4" />
+  </Spinner>
+);
+
+export default ButtonSpinner;

--- a/client/src/hooks/useSubscribe.js
+++ b/client/src/hooks/useSubscribe.js
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+import SubscribeButton from '../components/common/buttons/SubscribeButton';
+
+const useSubscribe = (postId, isSubscribed, fontSize = 12) => {
+  const [subscribed, setSubscribed] = useState(isSubscribed);
+  const [loading, setLoading] = useState(false);
+
+  // !REMOVE: sample api call
+  const API_CALL_SUB_OR_UNSUB = () => {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        if (subscribed) {
+          resolve('구독이 취소되었습니다.');
+        } else {
+          resolve('구독이 신청되었습니다.');
+        }
+      }, 2000);
+    });
+  };
+
+  const toggle = async () => {
+    setLoading(true);
+
+    //TODO: replace with axios sub/unsub api call
+    const { message } = await API_CALL_SUB_OR_UNSUB();
+
+    setSubscribed(subState => !subState);
+    setLoading(false);
+
+    //TODO: add custom Toast
+    //ex) addMessage({ message });
+  };
+
+  return () => (
+    <SubscribeButton
+      subscribed={subscribed}
+      toggle={toggle}
+      loading={loading}
+      fontSize={fontSize}
+    />
+  );
+};
+
+export default useSubscribe;

--- a/client/src/hooks/useSubscribe.js
+++ b/client/src/hooks/useSubscribe.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import SubscribeButton from '../components/common/buttons/SubscribeButton';
 
-const useSubscribe = (postId, isSubscribed, fontSize = 12) => {
+const useSubscribe = ({ postId, postType, subscribed: isSubscribed }, fontSize = 12) => {
   const [subscribed, setSubscribed] = useState(isSubscribed);
   const [loading, setLoading] = useState(false);
 


### PR DESCRIPTION
## 작업 내용
- 카트 컴포넌트 우측 상단에 들어가는 구독 버튼 컴포넌트 구현
- 구독 버튼을 누를 경우 API 요청을 mock 하기 위해 setTimeout 함수로 구현해 놓은 상태
- 요청이 시작되면 load spinner 가 표시되고 클릭 불가능한 영역으로 수정됨
- 요청이 끝나면 버튼 색상과, text가 바뀌고 다시 클릭 가능한 영역으로 바뀜

## 사용 예시 코드
```js
const CardItem = () => {
  const SubscribeBtn = useSubscribe({ postId, postType, subscribed }, 12); 
  // useSubscribe에서 받는 인자는 순서대로 postId, postType(= recipe or diet), subscribe 여부, 글씨 크기
  return (
    <CardContainer>
      <Header>
        <Title>{title}</Title>
        <SubscribeBtn />
      </Header>      
    </CardContainer>
  );
};
```

## 화면
- 구독 버튼
![image](https://user-images.githubusercontent.com/38288479/134773444-a7a4653d-0603-45f0-aed3-7581580e8779.png)
- 구독 완료
![image](https://user-images.githubusercontent.com/38288479/134773538-48212fe2-bfdd-480d-be6b-cd6e59c40eac.png)
- API 요청 중 spinner
![image](https://user-images.githubusercontent.com/38288479/134772229-f18c6220-43dd-4812-a4e4-55f7947da12d.png)