### PR TITLE
[Server] Feat: 레시피/식단 및 댓글 리스트 받아오기 구현

### DIFF
--- a/server/controller/comment/createComment.js
+++ b/server/controller/comment/createComment.js
@@ -37,13 +37,12 @@ module.exports = async (req, res) => {
         return res.status(400).send({ message: '유저 혹은 레시피 게시물이 존재하지 않습니다.' });
       }
 
-      const comment = new Comment({ content, user, postType });
+      const comment = new Comment({ content, user, post: postId, postType: 'recipe' });
+
       await Promise.all([
         comment.save(),
-        Recipe.updateOne({ _id: ObjectId(postId) }, { $push: { comments: comment } }),
+        Recipe.updateOne({ _id: ObjectId(postId) }, { $inc: { commentsCount: 1 } }),
       ]);
-
-      return res.status(200).send({ message: '댓글이 작성되었습니다.' });
     } else {
       const [user, diet] = await Promise.all([
         User.findById(ObjectId(payload)),
@@ -54,14 +53,13 @@ module.exports = async (req, res) => {
         return res.status(400).send({ message: '유저 혹은 식단 게시물이 존재하지 않습니다.' });
       }
 
-      const comment = new Comment({ content, user, postType });
+      const comment = new Comment({ content, user, post: postId, postType: 'diet' });
       await Promise.all([
         comment.save(),
-        Diet.updateOne({ _id: ObjectId(postId) }, { $push: { comments: comment } }),
+        Diet.updateOne({ _id: ObjectId(postId) }, { $inc: { commentsCount: 1 } }),
       ]);
-
-      return res.status(200).send({ message: '댓글이 작성되었습니다.' });
     }
+    return res.status(201).send({ message: '댓글이 작성되었습니다.' });
   } catch (err) {
     return res.status(500).send({ message: err.message });
   }

--- a/server/controller/comment/deleteComment.js
+++ b/server/controller/comment/deleteComment.js
@@ -14,7 +14,7 @@ module.exports = async (req, res) => {
       return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
     }
 
-    const { postType, commentId } = req.params;
+    const { postType, postId, commentId } = req.params;
     if (!isValidObjectId(commentId)) {
       return res.status(400).send({ message: '해당 댓글id는 유효하지 않습니다.' });
     }
@@ -30,18 +30,12 @@ module.exports = async (req, res) => {
     if (postType === 'recipes') {
       await Promise.all([
         Comment.deleteOne({ _id: ObjectId(commentId) }),
-        Recipe.updateOne(
-          { 'comments._id': ObjectId(commentId) },
-          { $pull: { comments: { _id: commentId } } },
-        ),
+        Recipe.updateOne({ _id: ObjectId(postId) }, { $inc: { commentsCount: -1 } }),
       ]);
     } else {
       await Promise.all([
         Comment.deleteOne({ _id: ObjectId(commentId) }),
-        Diet.updateOne(
-          { 'comments._id': ObjectId(commentId) },
-          { $pull: { comments: { _id: commentId } } },
-        ),
+        Diet.updateOne({ _id: ObjectId(postId) }, { $inc: { commentsCount: -1 } }),
       ]);
     }
     return res.status(200).send({ message: 'delete comment success' });

--- a/server/controller/comment/index.js
+++ b/server/controller/comment/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   createComment: require('./createComment'),
+  readComment: require('./readComment'),
   deleteComment: require('./deleteComment'),
   updateComment: require('./updateComment'),
 };

--- a/server/controller/comment/readComment.js
+++ b/server/controller/comment/readComment.js
@@ -1,0 +1,27 @@
+const { Comment } = require('../../models/comment');
+const {
+  isValidObjectId,
+  Types: { ObjectId },
+} = require('mongoose');
+
+module.exports = async (req, res) => {
+  try {
+    let { page = 1 } = req.query;
+    page = parseInt(page);
+    const { postType, postId } = req.params;
+    if (!(postType === 'recipes' || postType === 'diets')) {
+      return res.status(400).send({ message: '올바른 게시물 타입이 아닙니다.' });
+    }
+    if (!isValidObjectId(postId)) {
+      return res.status(400).send({ message: '해당 게시물id는 유효하지 않습니다.' });
+    }
+
+    const comments = await Comment.find({ post: ObjectId(postId) })
+      .sort({ createdAt: 1 })
+      .skip((page - 1) * 6)
+      .limit(6);
+    return res.status(200).send({ comments });
+  } catch (err) {
+    return res.status(500).send({ message: err.message });
+  }
+};

--- a/server/controller/comment/updateComment.js
+++ b/server/controller/comment/updateComment.js
@@ -1,6 +1,4 @@
 const { Comment } = require('../../models/comment');
-const { Diet } = require('../../models/diet');
-const { Recipe } = require('../../models/recipe');
 const { verifyAccessToken } = require('../utils/jwt');
 const {
   isValidObjectId,
@@ -34,18 +32,9 @@ module.exports = async (req, res) => {
     }
 
     if (postType === 'recipes') {
-      await Promise.all([
-        Comment.updateOne({ _id: ObjectId(commentId) }, { content }),
-        Recipe.updateOne(
-          { 'comments._id': ObjectId(commentId) },
-          { 'comments.$.content': content },
-        ),
-      ]);
+      await Comment.updateOne({ _id: ObjectId(commentId) }, { content });
     } else {
-      await Promise.all([
-        Comment.updateOne({ _id: ObjectId(commentId) }, { content }),
-        Diet.updateOne({ 'comments._id': ObjectId(commentId) }, { 'comments.$.content': content }),
-      ]);
+      await Comment.updateOne({ _id: ObjectId(commentId) }, { content });
     }
 
     return res.status(200).send({ message: 'modify comment success' });

--- a/server/controller/diet/readPostList.js
+++ b/server/controller/diet/readPostList.js
@@ -6,7 +6,7 @@ module.exports = async (req, res) => {
     page = parseInt(page);
     sort = parseInt(sort);
     const diets = await Diet.find({})
-      .sort({ updatedAt: sort })
+      .sort({ createdAt: sort })
       .skip((page - 1) * 8)
       .limit(8);
 

--- a/server/controller/diet/readPostList.js
+++ b/server/controller/diet/readPostList.js
@@ -1,0 +1,17 @@
+const { Diet } = require('../../models/diet');
+
+module.exports = async (req, res) => {
+  try {
+    let { page = 1, sort = -1 } = req.query;
+    page = parseInt(page);
+    sort = parseInt(sort);
+    const diets = await Diet.find({})
+      .sort({ updatedAt: sort })
+      .skip((page - 1) * 8)
+      .limit(8);
+
+    return res.status(200).send({ diets });
+  } catch (err) {
+    return res.status(500).send({ message: err.message });
+  }
+};

--- a/server/controller/recipe/index.js
+++ b/server/controller/recipe/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   createPost: require('./createPost'),
   readPost: require('./readPost'),
+  readPostList: require('./readPostList'),
   updatePost: require('./updatePost'),
   deletePost: require('./deletePost'),
 };

--- a/server/controller/recipe/readPostList.js
+++ b/server/controller/recipe/readPostList.js
@@ -1,0 +1,17 @@
+const { Recipe } = require('../../models/recipe');
+
+module.exports = async (req, res) => {
+  try {
+    let { page = 1, sort = -1 } = req.query;
+    page = parseInt(page);
+    sort = parseInt(sort);
+    const recipes = await Recipe.find({})
+      .sort({ updatedAt: sort })
+      .skip((page - 1) * 8)
+      .limit(8);
+
+    return res.status(200).send({ recipes });
+  } catch (err) {
+    return res.status(500).send({ message: err.message });
+  }
+};

--- a/server/controller/recipe/readPostList.js
+++ b/server/controller/recipe/readPostList.js
@@ -6,7 +6,7 @@ module.exports = async (req, res) => {
     page = parseInt(page);
     sort = parseInt(sort);
     const recipes = await Recipe.find({})
-      .sort({ updatedAt: sort })
+      .sort({ createdAt: sort })
       .skip((page - 1) * 8)
       .limit(8);
 

--- a/server/controller/user/info.js
+++ b/server/controller/user/info.js
@@ -63,28 +63,12 @@ module.exports = {
             'user.image_url': image_url,
           },
         ),
-        Recipe.updateMany(
-          {},
-          {
-            'comments.$[comment].user.nickname': nickname,
-            'comments.$[comment].user.image_url': image_url,
-          },
-          { arrayFilters: [{ 'comment.user._id': ObjectId(payload) }] },
-        ),
         Diet.updateMany(
           { 'user._id': ObjectId(payload) },
           {
             'user.nickname': nickname,
             'user.image_url': image_url,
           },
-        ),
-        Diet.updateMany(
-          {},
-          {
-            'comments.$[comment].user.nickname': nickname,
-            'comments.$[comment].user.image_url': image_url,
-          },
-          { arrayFilters: [{ 'comment.user._id': ObjectId(payload) }] },
         ),
         Comment.updateMany(
           { 'user._id': ObjectId(payload) },

--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -13,9 +13,13 @@ const commentSchema = new Schema(
       nickname: { type: String, required: true },
       image_url: { type: String, required: true },
     },
+    post: { type: ObjectId, refPath: 'postType' },
+    postType: { type: String, enum: ['recipe', 'diet'] },
   },
   { timestamps: true },
 );
+
+commentSchema.index({ createdAt: 1 });
 
 const Comment = model('comment', commentSchema);
 

--- a/server/models/diet.js
+++ b/server/models/diet.js
@@ -3,7 +3,6 @@ const {
   model,
   Types: { ObjectId },
 } = require('mongoose');
-const { commentSchema } = require('./comment');
 
 const dietSchema = new Schema(
   {
@@ -16,7 +15,7 @@ const dietSchema = new Schema(
       nickname: { type: String, required: true },
       image_url: { type: String, required: true },
     },
-    comments: [commentSchema],
+    commentsCount: { type: Number, default: 0 },
     like_user: { type: ObjectId, ref: 'user' },
     bookmark_user: { type: ObjectId, ref: 'user' },
     hashtag: { type: Array, ref: 'hashtag' },

--- a/server/models/recipe.js
+++ b/server/models/recipe.js
@@ -3,7 +3,6 @@ const {
   model,
   Types: { ObjectId },
 } = require('mongoose');
-const { commentSchema } = require('./comment');
 
 const recipeSchema = new Schema(
   {
@@ -15,7 +14,7 @@ const recipeSchema = new Schema(
       nickname: { type: String, required: true },
       image_url: { type: String, required: true },
     },
-    comments: [commentSchema],
+    commentsCount: { type: Number, default: 0 },
     like_user: { type: ObjectId, ref: 'user' },
     bookmark_user: { type: ObjectId, ref: 'user' },
     hashtag: { type: Array, ref: 'hashtag' },

--- a/server/routes/commentRoute.js
+++ b/server/routes/commentRoute.js
@@ -2,6 +2,8 @@ const { Router } = require('express');
 const commentRouter = Router({ mergeParams: true });
 const { commentController } = require('../controller');
 
+commentRouter.get('/', commentController.readComment);
+
 commentRouter.post('/', commentController.createComment);
 
 commentRouter.delete('/:commentId', commentController.deleteComment);

--- a/server/routes/recipeRoute.js
+++ b/server/routes/recipeRoute.js
@@ -6,6 +6,8 @@ recipeRouter.post('/', recipeController.createPost);
 
 recipeRouter.get('/:id', recipeController.readPost);
 
+recipeRouter.get('/', recipeController.readPostList);
+
 recipeRouter.patch('/:id', recipeController.updatePost);
 
 recipeRouter.delete('/:id', recipeController.deletePost);


### PR DESCRIPTION
## 레시피/식단 리스트 받아오기 부분
- GET recipes/, GET diets/ 라우터 구현
- 쿼리 파라미터로 page와 sort를 받아 레시피/식단 리스트들을 가져올 수 있음
  - page : 1부터 시작하도록 했으며, 한 페이지에 8개씩 받아올 수 있도록 하였음(페이지네이션)
  - sort: 현재는 1(등록순) 또는 -1(최신순)을 받을 수 있음

## 레시피/식단 스키마 부분
- 기존에 작성 댓글을 각 레시피/식단에 내장했었는데, 댓글이 많아질 수록 처리속도가 느려질 수 밖에 없음
  - 더군다나, 리스트를 받아올 때도 내장되어있는 댓글들까지 받아오도록 되어있었기 때문에 리스트를 받아올 때의 
  정보량이 기하급수적으로 늘어날 우려가 있었음
  - 그래서, 기존 comments 필드를 삭제하고 새로 라우터를 만들어, 해당 게시물의 댓글들을 불러올 수 있게 하였음
- 각 레시피/식단 및 리스트를 불러올 때는 해당 게시글의 댓글 작성갯수만 알 수 있게 commentsCount 필드를 추가하였음

## 댓글 부분
- GET /:postType/:postId/comments 라우터를 만들었음
- 쿼리 파라미터로 page를 받아 해당 게시글의 댓글들을 6개씩 나누어 받아올 수 있게 하였음
  - 한번에 다 받아와도 표시할 공간이 없다고 생각했기 때문에 이와같이 구현하였음
  - 작성 순서대로 받아올 수 있게 하였음

## 유저 삭제 부분
- 유저 삭제 요청 시 작성했던 댓글 삭제와 더불어, 게시물들의 댓글 갯수도 업데이트 될 수 있도록 하였음

## 레시피/식단 리스트
![Screenshot from 2021-09-26 15-37-21](https://user-images.githubusercontent.com/68040092/134796703-94dd0e01-dd2c-46db-85a9-cb67976bc796.png)
## 댓글 리스트
- 해당 게시물의 댓글이 7개고, 2페이지를 쿼리로 줬기 때문에 댓글 1개만 표시됨
![Screenshot from 2021-09-26 15-39-03](https://user-images.githubusercontent.com/68040092/134796707-de4dc1d1-e93b-4321-9316-a9dd0117403a.png)