### PR TITLE
[Client] Fix: props로 전달된 색상, 투명도, 너비, 높이에 따라 modal을 style할 수 있도록 수정

### DIFF
--- a/client/src/components/common/modal/Modal.js
+++ b/client/src/components/common/modal/Modal.js
@@ -9,8 +9,9 @@ const Overlay = styled.div`
   right: 0;
   top: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.2);
-  backdrop-filter: blur(1px);
+  background-color: ${({ color }) => color};
+  opacity: ${({ opacity }) => opacity};
+  z-index: 9;
 `;
 
 const ModalContainer = styled.div`
@@ -19,13 +20,14 @@ const ModalContainer = styled.div`
   right: 0;
   top: 0;
   bottom: 0;
-  width: 100%;
   max-width: 1130px;
-  height: 90%;
+  width: ${({ width }) => `${width}%`};
+  height: ${({ height }) => `${height}%`};
   margin: auto;
   padding: 3rem;
   border-radius: 10px;
   background: white;
+  z-index: 9;
 `;
 
 const CloseBtn = styled.div`
@@ -44,7 +46,7 @@ const Content = styled.div`
   height: 100%;
 `;
 
-const Modal = ({ children, hideModal }) => {
+const Modal = ({ children, hideModal, style }) => {
   useKeyPress('Escape', hideModal);
 
   const modalEl = document.getElementById('modal-root');
@@ -54,8 +56,8 @@ const Modal = ({ children, hideModal }) => {
 
   return ReactDOM.createPortal(
     <>
-      <Overlay onClick={hideModal} />
-      <ModalContainer>
+      <Overlay onClick={hideModal} color={style.overlayColor} opacity={style.overlayOpacity} />
+      <ModalContainer width={style.width} height={style.height}>
         <CloseBtn onClick={hideModal}>&times;</CloseBtn>
         <Content>{children}</Content>
       </ModalContainer>

--- a/client/src/hooks/useModal.js
+++ b/client/src/hooks/useModal.js
@@ -2,14 +2,22 @@ import { useState } from 'react';
 
 import Modal from '../components/common/modal/Modal';
 
-const useModal = () => {
+const useModal = (
+  style = { overlayColor: 'black', overlayOpacity: 0.2, width: 100, height: 90 },
+) => {
   const [isVisible, setIsVisible] = useState(false);
 
   const showModal = () => setIsVisible(true);
   const hideModal = () => setIsVisible(false);
 
   const ModalContainer = ({ children }) => (
-    <>{isVisible && <Modal hideModal={hideModal}>{children}</Modal>}</>
+    <>
+      {isVisible && (
+        <Modal hideModal={hideModal} style={style}>
+          {children}
+        </Modal>
+      )}
+    </>
   );
 
   return { isVisible, showModal, hideModal, ModalContainer };


### PR DESCRIPTION
## 수정사항
- props로 전달된 `색상`, `투명도`, `너비`, `높이`에 따라 modal style을 변경할 수 있도록 수정

## 사용 예시 코드
```js
import { useEffect } from 'react';
import useModal from '../hooks/useModal';

const RecipePage = () => {
  const modalStyle = { overlayColor: 'gray', overlayOpacity: 0.4, width: 50, height: 90 }; // width와 height의 단위는 % 입니다.
  const { isVisible, showModal, hideModal, ModalContainer } = useModal(modalStyle);

  useEffect(() => {
    showModal();
  }, []);

  return <ModalContainer></ModalContainer>;
};

export default RecipePage;

```