### PR TITLE
[Server] Feat: 구독 구현 및 유저 조회시 구독중인 유저의 정보 추가

### DIFF
--- a/server/controller/user/index.js
+++ b/server/controller/user/index.js
@@ -4,4 +4,6 @@ module.exports = {
   signout: require('./signout'),
   deleteAccount: require('./deleteAccount'),
   info: require('./info'),
+  subscribe: require('./subscribe'),
+  unsubscribe: require('./unsubscribe'),
 };

--- a/server/controller/user/info.js
+++ b/server/controller/user/info.js
@@ -2,6 +2,8 @@ const { User } = require('../../models/user');
 const { Recipe } = require('../../models/recipe');
 const { Diet } = require('../../models/diet');
 const { Comment } = require('../../models/comment');
+const { Like } = require('../../models/like');
+const { Bookmark } = require('../../models/bookmark');
 const { verifyAccessToken } = require('../utils/jwt');
 const {
   Types: { ObjectId },
@@ -15,7 +17,7 @@ module.exports = {
         return res.status(400).send({ message: '닉네임을 입력받지 않았습니다.' });
       }
 
-      User.findOne({ nickname }, (err, user) => {
+      User.findOne({ nickname }, async (err, user) => {
         if (err) {
           return res.status(400).send(err);
         }
@@ -24,9 +26,28 @@ module.exports = {
           return res.status(400).send({ message: '존재하지 않는 유저입니다.' });
         }
 
-        const { email, nickname, image_url = '' } = user;
+        const { email, nickname, image_url = '', subscribes } = user;
 
-        return res.status(200).send({ nickname, email, image_url });
+        const [likes, bookmarks] = await Promise.all([
+          Like.find({ user: user._id }),
+          Bookmark.find({ user: user._id }),
+        ]);
+
+        const subscribeUsers = await Promise.all(
+          subscribes.map(async subscribe => {
+            const user = await User.findOne({ _id: ObjectId(subscribe) });
+            const userInfo = {
+              email: user.email,
+              nickname: user.nickname,
+              image_url: user.image_url,
+            };
+            return userInfo;
+          }),
+        );
+
+        return res
+          .status(200)
+          .send({ nickname, email, image_url, likes, bookmarks, subscribeUsers });
       });
     } catch (err) {
       return res.status(500).send({ message: err.message });

--- a/server/controller/user/subscribe.js
+++ b/server/controller/user/subscribe.js
@@ -1,0 +1,40 @@
+const { User } = require('../../models/user');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  Types: { ObjectId },
+} = require('mongoose');
+module.exports = async (req, res) => {
+  try {
+    const { payload } = verifyAccessToken(req.cookies.accessToken);
+    if (!payload) {
+      return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+    }
+
+    const { nickname } = req.params;
+
+    const user = await User.findOne({ _id: ObjectId(payload) });
+
+    await User.findOne({ nickname }, async (err, subscribeUser) => {
+      if (err) {
+        return res.status(400).send(err);
+      }
+      if (!subscribeUser) {
+        return res.status(400).send({ message: '존재하지 않은 유저입니다.' });
+      }
+
+      if (user._id.equals(subscribeUser._id)) {
+        return res.status(400).send({ message: '자신은 구독할 수 없습니다.' });
+      }
+
+      if (user.subscribes.includes(subscribeUser._id)) {
+        return res.status(400).send({ message: '이미 구독한 유저입니다.' });
+      }
+
+      await User.updateOne({ _id: user._id }, { $push: { subscribes: subscribeUser._id } });
+
+      return res.status(200).send({ message: '해당 유저를 구독하였습니다.' });
+    });
+  } catch (err) {
+    return res.status(500).send({ message: err.message });
+  }
+};

--- a/server/controller/user/unsubscribe.js
+++ b/server/controller/user/unsubscribe.js
@@ -1,0 +1,33 @@
+const { User } = require('../../models/user');
+const { verifyAccessToken } = require('../utils/jwt');
+const {
+  Types: { ObjectId },
+} = require('mongoose');
+module.exports = async (req, res) => {
+  try {
+    const { payload } = verifyAccessToken(req.cookies.accessToken);
+    if (!payload) {
+      return res.status(400).send({ message: '유효하지 않은 접근입니다.' });
+    }
+
+    const { nickname } = req.params;
+
+    await User.findOne({ nickname }, async (err, subscribeUser) => {
+      if (err) {
+        return res.status(400).send(err);
+      }
+      if (!subscribeUser) {
+        return res.status(400).send({ message: '존재하지 않은 유저입니다.' });
+      }
+
+      await User.updateOne(
+        { _id: ObjectId(payload) },
+        { $pull: { subscribes: subscribeUser._id } },
+      );
+
+      return res.status(200).send({ message: '해당 유저를 구독취소하였습니다.' });
+    });
+  } catch (err) {
+    return res.status(500).send({ message: err.message });
+  }
+};

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,9 +1,5 @@
 require('dotenv').config();
-const {
-  Schema,
-  model,
-  Types: { ObjectId },
-} = require('mongoose');
+const { Schema, model } = require('mongoose');
 
 const bcrypt = require('bcrypt');
 let saltRound = 3; //salt를 돌리는 횟수
@@ -16,7 +12,7 @@ const userSchema = new Schema(
     nickname: { type: String, required: true, unique: true },
     image_url: { type: String, default: 'null' },
     refreshToken: String,
-    subscription: { type: ObjectId, ref: 'user' },
+    subscribes: Array,
   },
   { timestamps: true },
 );

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -14,4 +14,8 @@ userRouter.get('/:nickname', userController.info.get);
 
 userRouter.patch('/', userController.info.patch);
 
+userRouter.post('/subscribe/:nickname', userController.subscribe);
+
+userRouter.post('/unsubscribe/:nickname', userController.unsubscribe);
+
 module.exports = userRouter;


### PR DESCRIPTION
## 구독 부분
- POST /users/subscribe/:nickname 라우터 생성
- 로그인 상태 검사
- 닉네임에 맞는 유저 존재 여부 검사
- 자기 자신을 구독할 수 없게 하고, 이미 구독한 유저를 또 구독할 수 없게 하였음
- 구독 요청 정상처리 시, 현재 로그인 중인 유저 db의 subscribes 필드(배열 형태)에 구독할 유저의 id값 저장

## 구독 취소 부분
- POST /users/unsubscribe/:nickname 라우터 생성
- 로그인 상태 검사
- 닉네임에 맞는 유저 존재 여부 검사
- 현재 로그인 중인 유저 db의 subscribes 필드에서 구독취소할 유저의 id값만 제거됨
  - 현재 구독중이지 않은 유저에 대한 구독취소 요청의 경우는 정상적으로 가능한 상태이긴 하나, subscribes 필드에 id값이 등록되어있지 않았으므로 db에는 변화가 없음
  - 오히려 등록되어있지 않은 케이스를 찾으려는 비동기처리를 추가 하는게 처리가 더 무거워질 수 있다고 판단하여 해당 엣지케이스에 대한 처리를 추가하진 않았음

## 유저 정보 조회 부분
- subscribes 필드의 각 요소 값(구독중인 유저의 id값)을 이용하여, 해당 유저의 이메일, 닉네임, 이미지url 정보만 빼내어,  subscribeUsers라는 필드로 응답에 추가하였음

## 현재 수정한 유저 db 및 유저 정보 조회 예시
<details>
<summary>유저 db</summary>
<img src="https://user-images.githubusercontent.com/68040092/134926714-f5e4663d-9fa0-441f-94a6-7bfdef2414b7.png"/>
</details>

<details>
<summary>유저 정보 조회 응답</summary>
<img src="https://user-images.githubusercontent.com/68040092/134928668-dd8eb85a-f03a-4a42-8067-fa19cb4bc2e1.png"/>
</details>
