### PR TITLE
[Server] Feat: 게시물 검색 기능 구현

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -12,6 +12,7 @@ const {
   commentRouter,
   likeRouter,
   bookmarkRouter,
+  searchRouter,
 } = require('./routes');
 
 const server = async () => {
@@ -49,6 +50,7 @@ const server = async () => {
     app.use('/:postType/:postId/comments', commentRouter);
     app.use('/:postType/:postId/likes', likeRouter);
     app.use('/:postType/:postId/bookmarks', bookmarkRouter);
+    app.use('/search', searchRouter);
 
     app.listen(port, () => console.log(`server listening on port ${port}`));
   } catch (err) {

--- a/server/controller/diet/createPost.js
+++ b/server/controller/diet/createPost.js
@@ -13,14 +13,14 @@ module.exports = async (req, res) => {
     }
 
     const user = await User.findById(ObjectId(payload));
-    const { title, subtitle, content, hashtag = [] } = req.body;
+    const { title, subtitle, content, hashtags = [] } = req.body;
 
     const post = new Diet({
       title,
       subtitle,
       content,
       user,
-      hashtag,
+      hashtags,
     });
     await post.save();
     return res.status(201).send({ message: '식단 작성이 완료되었습니다.' });

--- a/server/controller/diet/deletePost.js
+++ b/server/controller/diet/deletePost.js
@@ -22,6 +22,10 @@ module.exports = async (req, res) => {
 
     const diet = await Diet.findOne({ _id: id });
 
+    if (!diet) {
+      return res.status(400).send({ message: '존재하지 않는 게시물입니다.' });
+    }
+
     if (!diet.user._id.equals(ObjectId(payload))) {
       return res.status(400).send({ message: '게시물의 작성자만 삭제할 수 있습니다' });
     }

--- a/server/controller/diet/index.js
+++ b/server/controller/diet/index.js
@@ -3,4 +3,5 @@ module.exports = {
   readPost: require('./readPost'),
   updatePost: require('./updatePost'),
   deletePost: require('./deletePost'),
+  readPostList: require('./readPostList'),
 };

--- a/server/controller/diet/readPostList.js
+++ b/server/controller/diet/readPostList.js
@@ -2,13 +2,35 @@ const { Diet } = require('../../models/diet');
 
 module.exports = async (req, res) => {
   try {
-    let { page = 1, sort = -1 } = req.query;
+    let { page = 1, sort = -1, hashtag, user, title } = req.query;
+
+    if (!hashtag && !user && !title) {
+      const diets = await Diet.find({})
+        .sort({ createdAt: sort })
+        .skip((page - 1) * 8)
+        .limit(8);
+      return res.status(200).send({ diets });
+    }
     page = parseInt(page);
     sort = parseInt(sort);
-    const diets = await Diet.find({})
-      .sort({ createdAt: sort })
-      .skip((page - 1) * 8)
-      .limit(8);
+
+    let diets;
+    if (title) {
+      diets = await Diet.find({ title: new RegExp(title) })
+        .sort({ createdAt: sort })
+        .skip((page - 1) * 8)
+        .limit(8);
+    } else if (hashtag) {
+      diets = await Diet.find({ hashtags: hashtag })
+        .sort({ createdAt: sort })
+        .skip((page - 1) * 8)
+        .limit(8);
+    } else {
+      diets = await Diet.find({ 'user.nickname': user })
+        .sort({ createdAt: sort })
+        .skip((page - 1) * 8)
+        .limit(8);
+    }
 
     return res.status(200).send({ diets });
   } catch (err) {

--- a/server/controller/index.js
+++ b/server/controller/index.js
@@ -5,4 +5,5 @@ module.exports = {
   commentController: require('./comment'),
   likeController: require('./like'),
   bookmarkController: require('./bookmark'),
+  searchController: require('./search'),
 };

--- a/server/controller/recipe/createPost.js
+++ b/server/controller/recipe/createPost.js
@@ -13,13 +13,13 @@ module.exports = async (req, res) => {
     }
 
     const user = await User.findById(ObjectId(payload));
-    const { title, content, hashtag = [] } = req.body;
+    const { title, content, hashtags = [] } = req.body;
 
     const post = new Recipe({
       title,
       content,
       user,
-      hashtag,
+      hashtags,
     });
     await post.save();
     return res.status(201).send({ message: '레시피 작성이 완료되었습니다.' });

--- a/server/controller/recipe/readPostList.js
+++ b/server/controller/recipe/readPostList.js
@@ -2,13 +2,35 @@ const { Recipe } = require('../../models/recipe');
 
 module.exports = async (req, res) => {
   try {
-    let { page = 1, sort = -1 } = req.query;
+    let { page = 1, sort = -1, hashtag, user, title } = req.query;
+
+    if (!hashtag && !user && !title) {
+      const recipes = await Recipe.find({})
+        .sort({ createdAt: sort })
+        .skip((page - 1) * 8)
+        .limit(8);
+      return res.status(200).send({ recipes });
+    }
     page = parseInt(page);
     sort = parseInt(sort);
-    const recipes = await Recipe.find({})
-      .sort({ createdAt: sort })
-      .skip((page - 1) * 8)
-      .limit(8);
+
+    let recipes;
+    if (title) {
+      recipes = await Recipe.find({ title: new RegExp(title) })
+        .sort({ createdAt: sort })
+        .skip((page - 1) * 8)
+        .limit(8);
+    } else if (hashtag) {
+      recipes = await Recipe.find({ hashtags: hashtag })
+        .sort({ createdAt: sort })
+        .skip((page - 1) * 8)
+        .limit(8);
+    } else {
+      recipes = await Recipe.find({ 'user.nickname': user })
+        .sort({ createdAt: sort })
+        .skip((page - 1) * 8)
+        .limit(8);
+    }
 
     return res.status(200).send({ recipes });
   } catch (err) {

--- a/server/controller/search/index.js
+++ b/server/controller/search/index.js
@@ -1,0 +1,24 @@
+module.exports = (req, res) => {
+  try {
+    const { postType, input } = req.body;
+    if (postType === '레시피') {
+      if (input[0] === '#') {
+        return res.redirect(`/recipes?hashtag=${input.slice(1)}`);
+      } else if (input[0] === '@') {
+        return res.redirect(`/recipes?user=${input.slice(1)}`);
+      } else {
+        return res.redirect(`/recipes?title=${input.slice(1)}`);
+      }
+    } else {
+      if (input[0] === '#') {
+        return res.redirect(`/diets?hashtag=${input.slice(1)}`);
+      } else if (input[0] === '@') {
+        return res.redirect(`/diets?user=${input.slice(1)}`);
+      } else {
+        return res.redirect(`/diets?title=${input.slice(1)}`);
+      }
+    }
+  } catch (err) {
+    return res.status(500).send({ message: err.message });
+  }
+};

--- a/server/controller/user/emailValidation.js
+++ b/server/controller/user/emailValidation.js
@@ -1,0 +1,24 @@
+const { User } = require('../../models/user');
+
+module.exports = (req, res) => {
+  try {
+    const { email } = req.body;
+
+    if (!email) {
+      return res.status(400).send({ message: '이메일을 입력받지 않았습니다.' });
+    }
+
+    User.findOne({ email }, (err, user) => {
+      if (err) {
+        return res.status(400).send(err);
+      }
+      if (user) {
+        return res.status(400).send({ message: '이미 존재하는 이메일입니다.' });
+      } else {
+        return res.status(200).send({ message: '사용가능한 이메일입니다.' });
+      }
+    });
+  } catch (err) {
+    return res.status(500).send({ message: err.message });
+  }
+};

--- a/server/controller/user/index.js
+++ b/server/controller/user/index.js
@@ -7,4 +7,5 @@ module.exports = {
   subscribe: require('./subscribe'),
   unsubscribe: require('./unsubscribe'),
   nicknameValidation: require('./nicknameValidation'),
+  emailValidation: require('./emailValidation'),
 };

--- a/server/controller/user/nicknameValidation.js
+++ b/server/controller/user/nicknameValidation.js
@@ -2,7 +2,11 @@ const { User } = require('../../models/user');
 
 module.exports = (req, res) => {
   try {
-    const { nickname } = req.params;
+    const { nickname } = req.body;
+
+    if (!nickname) {
+      return res.status(400).send({ message: '닉네임을 입력받지 않았습니다.' });
+    }
 
     User.findOne({ nickname }, (err, user) => {
       if (err) {

--- a/server/models/diet.js
+++ b/server/models/diet.js
@@ -19,7 +19,7 @@ const dietSchema = new Schema(
     commentsCount: { type: Number, default: 0 },
     likesCount: { type: Number, default: 0 },
     bookmarksCount: { type: Number, default: 0 },
-    hashtag: { type: Array, ref: 'hashtag' },
+    hashtags: { type: Array, ref: 'hashtag' },
   },
   { timestamps: true },
 );

--- a/server/models/recipe.js
+++ b/server/models/recipe.js
@@ -17,7 +17,7 @@ const recipeSchema = new Schema(
     commentsCount: { type: Number, default: 0 },
     likesCount: { type: Number, default: 0 },
     bookmarksCount: { type: Number, default: 0 },
-    hashtag: { type: Array, ref: 'hashtag' },
+    hashtags: { type: Array, ref: 'hashtag' },
     thumbnail_url: { type: String, default: 'thumbnail' },
     originalFileName: { type: String, default: 'fileName' },
   },

--- a/server/routes/dietRoute.js
+++ b/server/routes/dietRoute.js
@@ -7,6 +7,8 @@ dietRouter.post('/', checkToken, dietController.createPost);
 
 dietRouter.get('/:id', dietController.readPost);
 
+dietRouter.get('/', dietController.readPostList);
+
 dietRouter.patch('/:id', checkToken, dietController.updatePost);
 
 dietRouter.delete('/:id', checkToken, dietController.deletePost);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -5,4 +5,5 @@ module.exports = {
   commentRouter: require('./commentRoute'),
   likeRouter: require('./likeRoute'),
   bookmarkRouter: require('./bookmarkRoute'),
+  searchRouter: require('./searchRouter'),
 };

--- a/server/routes/searchRouter.js
+++ b/server/routes/searchRouter.js
@@ -1,0 +1,7 @@
+const { Router } = require('express');
+const searchRouter = Router();
+const { searchController } = require('../controller');
+
+searchRouter.post('/', searchController);
+
+module.exports = searchRouter;

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -19,6 +19,8 @@ userRouter.post('/subscribe/:nickname', checkToken, userController.subscribe);
 
 userRouter.post('/unsubscribe/:nickname', checkToken, userController.unsubscribe);
 
-userRouter.post('/:nickname', userController.nicknameValidation);
+userRouter.post('/nickname', userController.nicknameValidation);
+
+userRouter.post('/email', userController.emailValidation);
 
 module.exports = userRouter;


### PR DESCRIPTION
## 검색 기능 부분
- POST /search 라우터 구현
- request body로, postType과 input을 받아서 처리함
  - postType : '레시피' or '식단'
  - input
    - 게시물 제목 검색 : 검색문자열
    - 특정 유저가 작성한 게시물 검색 : @검색문자열
    - 게시물의 특정 해시태그 여부에 따른 검색 : #검색문자열
- 요청이 정상적으로 처리되면 레시피/식단 리스트 url로 리다이렉트함

## 게시물(레시피/식단) 리스트 부분
- 쿼리 변수로 hashtag, title, user를 추가
- 각 변수 중 하나만 존재한다는 가정하에 코드를 구성하였고, 해당하는 조건으로 필터링을 하게 되어있음
- 기존 카드 리스트와 같이 8개 단위로 페이지네이션을 하도록 되어있음
- 위의 3개의 변수를 다 받지 않았을 때는 필터링 조건 없이 모든 게시물이 정렬되게 하였음

## 게시물 부분
- hashtag => hastags로 필드 이름을 변경하였음
  - 이에 따른 게시물 작성 시 처리도 변수명에 맞춰 변경하였음

## 검색 요청 및 응답 예시
<details>
<summary>검색 요청&응답</summary>
<img src="https://user-images.githubusercontent.com/68040092/135048738-c7b7313f-34ec-4222-a85f-adb74b023983.png"/>
</details>
- 