### PR TITLE
[Client] Feat: 회원가입 모달 구현

### DIFF
--- a/client/src/components/auth/Signup.js
+++ b/client/src/components/auth/Signup.js
@@ -1,0 +1,210 @@
+import { useRef, useState } from 'react';
+import styled from 'styled-components';
+import axios from 'axios';
+
+import InputForm from '../common/forms/InputForm';
+import validator from '../../utils/validation';
+import useToast from '../../hooks/toast/useToast';
+
+const Wrapper = styled.div`
+  text-align: center;
+`;
+
+const Header = styled.div``;
+
+const Logo = styled.div`
+  font-size: 2rem;
+`;
+
+const Title = styled.div`
+  margin-top: 1em;
+  font-size: 1.1rem;
+`;
+
+const Form = styled.form`
+  margin-top: 2em;
+`;
+
+const UserInput = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+  margin-bottom: 5rem;
+`;
+
+const SubmitBtn = styled.button`
+  width: 100%;
+  height: 2.5em;
+  color: white;
+  background-color: #ffc436;
+  font-size: 1.2rem;
+  border: none;
+  border-radius: 5px;
+  &:hover {
+    cursor: pointer;
+    opacity: 0.8;
+  }
+`;
+
+const Footer = styled.div`
+  margin-top: 2rem;
+`;
+
+const LoginLink = styled.span`
+  margin-left: 0.5rem;
+  color: #ffc436;
+  font-weight: bold;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const Signup = ({ handleMenuClick }) => {
+  const [isValidPwd, setIsValidPwd] = useState(false);
+  const emailRef = useRef();
+  const nicknameRef = useRef();
+  const pwdRef = useRef();
+  const pwdConfirmRef = useRef();
+
+  const addMessage = useToast();
+
+  const checkRefs = () => {
+    const refs = [emailRef, nicknameRef, pwdRef, pwdConfirmRef];
+    for (const ref of refs) {
+      const isValid = ref.current?.getValidation();
+      if (!isValid) {
+        ref.current.focusInputRef();
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const allRefsValid = checkRefs();
+    if (!allRefsValid) {
+      return;
+    }
+
+    try {
+      const {
+        data: { message },
+        status,
+      } = await axios.post(`${process.env.REACT_APP_ENDPOINT_URL}/users/signup`, {
+        email: emailRef.current.getInput(),
+        nickname: nicknameRef.current.getInput(),
+        password: pwdRef.current.getInput(),
+      });
+
+      if (status === 201) {
+        addMessage({ message }, () => {
+          handleMenuClick('signin');
+        });
+      } else {
+        addMessage({ mode: 'error', message: '이미 가입된 이메일 입니다.' });
+      }
+    } catch (err) {
+      addMessage({ mode: 'error', message: '서버오류로 인해 회원가입을 진행할 수 없습니다.' });
+    }
+  };
+
+  const validateEmail = email => {
+    return new Promise(resolve => {
+      const isValid = validator('email', email);
+      if (isValid) {
+        axios
+          .post(`${process.env.REACT_APP_ENDPOINT_URL}/users/email`, { email })
+          .then(({ data: { message }, status }) => {
+            if (status === 200) {
+              resolve({ result: true, message });
+            } else {
+              resolve({ result: false, message });
+            }
+          });
+      } else {
+        resolve({ result: false, message: '사용 불가능한 이메일 형식입니다.' });
+      }
+    });
+  };
+
+  const validateNickname = nickname => {
+    return new Promise(resolve => {
+      axios
+        .post(`${process.env.REACT_APP_ENDPOINT_URL}/users/nickname`, { nickname })
+        .then(({ data: { message }, status }) => {
+          if (status === 200) {
+            resolve({ result: true, message });
+          } else {
+            resolve({ result: false, message });
+          }
+        });
+    });
+  };
+
+  const validatePassword = password => {
+    return new Promise(resolve => {
+      const isValid = validator('password', password);
+      if (isValid) {
+        resolve({ result: true, message: '사용가능한 비밀번호 형식입니다.' });
+        setIsValidPwd(true);
+      } else {
+        resolve({
+          result: false,
+          message: '영어소문자, 숫자 포함 8자 이상의 비밀번호를 입력해주세요.',
+        });
+        setIsValidPwd(false);
+      }
+    });
+  };
+
+  const validatePasswordConfirm = passwordConfirm => {
+    return new Promise(resolve => {
+      const isValid = passwordConfirm === pwdRef.current.getInput();
+      if (isValid) {
+        resolve({ result: true, message: '비밀번호가 일치합니다.' });
+      } else {
+        resolve({ result: false, message: '비밀번호가 일치하지 않습니다' });
+      }
+    });
+  };
+
+  return (
+    <Wrapper>
+      <Header>
+        <Logo>Logo</Logo>
+        <Title>회원가입</Title>
+      </Header>
+      <Form>
+        <UserInput>
+          <InputForm ref={emailRef} placeholder="이메일" type="text" validate={validateEmail} />
+          <InputForm
+            ref={nicknameRef}
+            placeholder="닉네임"
+            type="text"
+            validate={validateNickname}
+          />
+          <InputForm
+            ref={pwdRef}
+            placeholder="비밀번호"
+            type="password"
+            validate={validatePassword}
+          />
+          <InputForm
+            ref={pwdConfirmRef}
+            placeholder="비밀번호 확인"
+            type="password"
+            validate={validatePasswordConfirm}
+            disabled={!isValidPwd}
+          />
+        </UserInput>
+        <SubmitBtn onClick={handleSubmit}>회원가입</SubmitBtn>
+      </Form>
+      <Footer>
+        이미 회원이신가요? <LoginLink onClick={() => handleMenuClick('signin')}>로그인</LoginLink>
+      </Footer>
+    </Wrapper>
+  );
+};
+
+export default Signup;

--- a/client/src/components/common/ToastPortal/ToastPortal.js
+++ b/client/src/components/common/ToastPortal/ToastPortal.js
@@ -22,8 +22,11 @@ const ToastPortal = forwardRef((_, ref) => {
   const handleClose = id => setToasts(toasts.filter(toast => toast.id !== id));
 
   useImperativeHandle(ref, () => ({
-    addMessage(toast) {
+    addMessage(toast, cb) {
       setToasts([...toasts, { ...toast, id: uuid() }]);
+      if (cb && typeof cb === 'function') {
+        setTimeout(cb, toast.delay + SLIDE_DELAY);
+      }
     },
   }));
 

--- a/client/src/components/common/forms/InputForm.js
+++ b/client/src/components/common/forms/InputForm.js
@@ -1,0 +1,71 @@
+import { forwardRef, useRef, useState, useEffect, useImperativeHandle } from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  border: none;
+  border-bottom: 1px solid #cdc5bf;
+  font-size: 1.1rem;
+  &:focus {
+    outline: none;
+    border-bottom: 2px solid #222222;
+    margin-bottom: -1px;
+  }
+`;
+
+const ValidationMessage = styled.div`
+  position: absolute;
+  top: 30px;
+  color: ${({ isValid }) => (isValid ? '#07bc0c' : '#e74c3c')};
+`;
+
+const InputForm = ({ placeholder, validate, type, disabled }, ref) => {
+  const inputRef = useRef();
+  const [input, setInput] = useState('');
+  const [validation, setValidation] = useState(null);
+
+  const handleChange = e => {
+    setInput(e.target.value);
+  };
+
+  useEffect(() => {
+    if (!input.trim()) {
+      return;
+    }
+    const timerId = setTimeout(() => {
+      validate(input).then(({ result, message }) => {
+        setValidation({ result, message });
+      });
+    }, 1000);
+
+    return () => clearTimeout(timerId);
+  }, [input, validate]);
+
+  useImperativeHandle(ref, () => ({
+    getInput: () => input,
+    getValidation: () => !!validation?.result,
+    focusInputRef: () => inputRef.current.focus(),
+  }));
+
+  return (
+    <Wrapper>
+      <Input
+        placeholder={placeholder}
+        type={type}
+        onChange={handleChange}
+        disabled={disabled}
+        ref={inputRef}
+      />
+      {input.length > 0 && (
+        <ValidationMessage isValid={!!validation?.result}>{validation?.message}</ValidationMessage>
+      )}
+    </Wrapper>
+  );
+};
+
+export default forwardRef(InputForm);

--- a/client/src/components/common/modal/Modal.js
+++ b/client/src/components/common/modal/Modal.js
@@ -3,14 +3,16 @@ import styled from 'styled-components';
 
 import useKeyPress from '../../../hooks/useKeyPress';
 
+const { REACT_APP_WEB_MAX_WIDTH } = process.env;
+
 const Overlay = styled.div`
   position: fixed;
   left: 0;
   right: 0;
   top: 0;
   bottom: 0;
-  background-color: ${({ color }) => color};
-  opacity: ${({ opacity }) => opacity};
+  background-color: ${({ color }) => (color ? color : 'black')};
+  opacity: ${({ opacity }) => (opacity ? opacity : 0.2)};
   z-index: 9;
 `;
 
@@ -20,14 +22,30 @@ const ModalContainer = styled.div`
   right: 0;
   top: 0;
   bottom: 0;
-  max-width: 1130px;
-  width: ${({ width }) => `${width}%`};
-  height: ${({ height }) => `${height}%`};
+  min-width: 600px;
+  max-width: ${REACT_APP_WEB_MAX_WIDTH};
+  width: ${({ width }) => (width ? `${width}%` : '100%')};
+  height: ${({ height }) => (height ? `${height}%` : '90%')};
   margin: auto;
-  padding: 3rem;
+  padding: ${({ padding }) => (padding ? `${padding}em` : '3rem')};
   border-radius: 10px;
   background: white;
   z-index: 9;
+  overflow-y: auto;
+  box-shadow: 1px 3px 3px 1px rgba(0, 0, 0, 0.2);
+  animation: slideIn 0.3s linear;
+  @media screen and (max-width: 768px) {
+    width: 100%;
+    min-width: 100%;
+  }
+  @keyframes slideIn {
+    0% {
+      bottom: -50%;
+    }
+    100% {
+      bottom: 0;
+    }
+  }
 `;
 
 const CloseBtn = styled.div`
@@ -57,7 +75,7 @@ const Modal = ({ children, hideModal, style }) => {
   return ReactDOM.createPortal(
     <>
       <Overlay onClick={hideModal} color={style.overlayColor} opacity={style.overlayOpacity} />
-      <ModalContainer width={style.width} height={style.height}>
+      <ModalContainer width={style.width} height={style.height} padding={style.padding}>
         <CloseBtn onClick={hideModal}>&times;</CloseBtn>
         <Content>{children}</Content>
       </ModalContainer>

--- a/client/src/components/header/RightContainer.js
+++ b/client/src/components/header/RightContainer.js
@@ -1,6 +1,9 @@
-import React from 'react';
+import { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { NavLink } from 'react-router-dom';
+
+import useModal from '../../hooks/useModal';
+import Signup from '../auth/Signup';
 
 const StyledLink = styled(NavLink)`
   text-decoration: none !important;
@@ -121,34 +124,48 @@ const RightContainer = ({
   handleDropdown,
   useHamburgerMenu,
 }) => {
+  const [modalContent, setModalContent] = useState('');
+  const { showModal, ModalContainer } = useModal({ width: 30, height: 70, padding: 2.5 });
+
+  const handleMenuClick = menu => {
+    setModalContent(menu);
+    showModal();
+  };
+
   return (
-    <Container active={useHamburgerMenu}>
-      <div>login</div>
-      <div>sign up</div>
-      <WriteByMobile ref={popRef}>
-        <StyledLink to="/RecipeEditPage" onClick={handleHamburgerMenu}>
-          레시피
-        </StyledLink>
-        <StyledLink to="/DietEditPage" onClick={handleHamburgerMenu}>
-          식단
-        </StyledLink>
-      </WriteByMobile>
-      <WriteContainer ref={popRef}>
-        <button onClick={handleDropdown}>
-          write
-          {useDropdown && (
-            <DropdownContainer>
-              <StyledLink to="/RecipeEditPage" onClick={handleDropdown}>
-                레시피
-              </StyledLink>
-              <StyledLink to="/DietEditPage" onClick={handleDropdown}>
-                식단
-              </StyledLink>
-            </DropdownContainer>
-          )}
-        </button>
-      </WriteContainer>
-    </Container>
+    <>
+      <ModalContainer>
+        {modalContent === 'signup' && <Signup handleMenuClick={handleMenuClick} />}
+        {modalContent === 'signin' && <div>signin 입니다</div>}
+      </ModalContainer>
+      <Container active={useHamburgerMenu}>
+        <div onClick={() => handleMenuClick('signin')}>login</div>
+        <div onClick={() => handleMenuClick('signup')}>sign up</div>
+        <WriteByMobile ref={popRef}>
+          <StyledLink to="/RecipeEditPage" onClick={handleHamburgerMenu}>
+            레시피
+          </StyledLink>
+          <StyledLink to="/DietEditPage" onClick={handleHamburgerMenu}>
+            식단
+          </StyledLink>
+        </WriteByMobile>
+        <WriteContainer ref={popRef}>
+          <button onClick={handleDropdown}>
+            write
+            {useDropdown && (
+              <DropdownContainer>
+                <StyledLink to="/RecipeEditPage" onClick={handleDropdown}>
+                  레시피
+                </StyledLink>
+                <StyledLink to="/DietEditPage" onClick={handleDropdown}>
+                  식단
+                </StyledLink>
+              </DropdownContainer>
+            )}
+          </button>
+        </WriteContainer>
+      </Container>
+    </>
   );
 };
 

--- a/client/src/hooks/toast/useToast.js
+++ b/client/src/hooks/toast/useToast.js
@@ -4,12 +4,15 @@ import { TOAST_DELAY } from '../../components/common/ToastPortal/constants';
 
 const useToast = () => {
   const { toastRef } = useSelector(state => state.toastReducer);
-  const addMessage = ({ mode = 'success', message, delay = TOAST_DELAY }) => {
-    toastRef.current.addMessage({
-      mode,
-      message,
-      delay,
-    });
+  const addMessage = ({ mode = 'success', message, delay = TOAST_DELAY }, cb) => {
+    toastRef.current.addMessage(
+      {
+        mode,
+        message,
+        delay,
+      },
+      cb,
+    );
   };
 
   return addMessage;

--- a/client/src/hooks/useModal.js
+++ b/client/src/hooks/useModal.js
@@ -2,9 +2,7 @@ import { useState } from 'react';
 
 import Modal from '../components/common/modal/Modal';
 
-const useModal = (
-  style = { overlayColor: 'black', overlayOpacity: 0.2, width: 100, height: 90 },
-) => {
+const useModal = style => {
   const [isVisible, setIsVisible] = useState(false);
 
   const showModal = () => setIsVisible(true);

--- a/client/src/utils/validation.js
+++ b/client/src/utils/validation.js
@@ -1,0 +1,8 @@
+const regex = {
+  email: /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/,
+  password: /(?=.*\d)(?=.*[a-z]).{8,}/, // 영어소문자, 숫자 포함 8자 이상의 비밀번호.
+};
+
+const validator = (type, str) => !!regex[type].exec(str);
+
+export default validator;


### PR DESCRIPTION
## 작업 내용
- 헤더창 우측의 회원가입 버튼을 누를 경우 띄워지는 모달 구현
- email, nickname, password 에 대한 마지막 입력으로부터 1초 후 형식 검사를 실행
- email, nickname 경우 올바른 형식인 경우 server에 중복 검사 요청을 보냄
- 모든 항목이 입력되고, 유효할 때에만 회원가입 요청이 전송됨
- 회원가입이 정상적으로 진행되면 toast를 통해 메시지가 화면에 띄워지고 로그인 modal이 열리도록 설정
- 특정 항목이 빠졌거나, 정상적인 값으로 인정되지 않을 경우 focus가 가도록 설정

## 화면
![image](https://user-images.githubusercontent.com/38288479/135049581-69456362-e7c0-417a-a714-5f99dfc8547c.png)
