### PR TITLE
[Server] Feat: 관리자 권한 추가, Fix : signin 응답 시 유저 정보 전달, README 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@
 
 ## Server-Side Flow Chart
 
-![Client-Side Flow Chart](https://user-images.githubusercontent.com/68040092/135194280-ec21154d-b30b-425d-8543-ac7cc2622613.png)
+![Server-Side Flow Chart](https://user-images.githubusercontent.com/68040092/135194280-ec21154d-b30b-425d-8543-ac7cc2622613.png)
 
 ## Deployment Architecture
 
-![Client-Side Flow Chart](https://user-images.githubusercontent.com/38288479/134836470-b06fb1d1-32df-4111-8d22-d32094bf1989.png)
+![Deployment Architecture](https://user-images.githubusercontent.com/38288479/134836470-b06fb1d1-32df-4111-8d22-d32094bf1989.png)
 
 # Menu.random()팀의 멤버를 소개합니다.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 '매일 점심 시간마다 뭘 먹을까 고민이신가요?'  
 '적은 돈으로 만들 수 있는 식사를 찾고 계신가요?'  
-'살 쭉쭉 빠지는 다이어트 식단을 없을까?'  
+'살 쭉쭉 빠지는 다이어트 식단을 없을까?'
 
-당신의 매니저가 되어 당신의 고민을 끝내드리겠습니다.  
+당신의 매니저가 되어 당신의 고민을 끝내드리겠습니다.
 
-대한민국의 모든 밥 고민을 없애줄 서비스 `Menuger` 입니다.  
+대한민국의 모든 밥 고민을 없애줄 서비스 `Menuger` 입니다.
 
 # 사용한 스택
 
@@ -15,13 +15,14 @@
 ![JSLogo](https://img.shields.io/badge/FRONT-JAVASCRIPT-yellow?style=for-the-badge&logo=javascript)
 ![ReactLogo](https://img.shields.io/badge/FRONT-REACT-9cf?style=for-the-badge&logo=react)
 ![React-RouterLogo](https://img.shields.io/badge/FRONT-REACT--ROUTER-critical?style=for-the-badge&logo=react-router)
+![Styled-ComponentsLogo](https://img.shields.io/badge/FRONT-Styled--Components-ff69b4?style=for-the-badge&logo=styled-components)
 
 ## BACK-END
 
-![NodeJSLogo](https://img.shields.io/badge/BACK-REACT-green?style=for-the-badge&logo=node.js)
+![NodeJSLogo](https://img.shields.io/badge/BACK-NODEJS-green?style=for-the-badge&logo=node.js)
 ![ExpressLogo](https://img.shields.io/badge/BACK-EXPRESS-black?style=for-the-badge&logo=express)
-![SequelizeLogo](https://img.shields.io/badge/BACK-SEQUELIZE-9cf?style=for-the-badge&logo=sequelize)
-![MysqlLogo](https://img.shields.io/badge/BACK-MYSQL-blue?style=for-the-badge&logo=mysql)
+![MongoDBLogo](https://img.shields.io/badge/BACK-MONGODB-success?style=for-the-badge&logo=mongodb)
+![MongooseLogo](https://img.shields.io/badge/BACK-Mongoose-red?style=for-the-badge)
 ![JWTLogo](https://img.shields.io/badge/BACK-JSON--WEB--TOKEN-inactive?style=for-the-badge&logo=json-web-tokens)
 
 # Architecture
@@ -32,11 +33,11 @@
 
 ## Server-Side Flow Chart
 
-![Client-Side Flow Chart](https://user-images.githubusercontent.com/68040092/132823269-bd6c67a8-eb1b-4869-8498-592af63fb21d.png)
+![Client-Side Flow Chart](https://user-images.githubusercontent.com/68040092/135194280-ec21154d-b30b-425d-8543-ac7cc2622613.png)
 
 ## Deployment Architecture
 
-![Client-Side Flow Chart](https://user-images.githubusercontent.com/38288479/132779491-20092270-c28a-471f-bda0-5d0ebd7cad42.png)
+![Client-Side Flow Chart](https://user-images.githubusercontent.com/38288479/134836470-b06fb1d1-32df-4111-8d22-d32094bf1989.png)
 
 # Menu.random()팀의 멤버를 소개합니다.
 

--- a/server/controller/comment/deleteComment.js
+++ b/server/controller/comment/deleteComment.js
@@ -1,3 +1,4 @@
+const { User } = require('../../models/user');
 const { Comment } = require('../../models/comment');
 const { Diet } = require('../../models/diet');
 const { Recipe } = require('../../models/recipe');
@@ -24,9 +25,14 @@ module.exports = async (req, res) => {
       return res.status(400).send({ message: '존재하지 않는 댓글입니다.' });
     }
 
-    if (!comment.user._id.equals(ObjectId(payload))) {
-      return res.status(400).send({ message: '댓글 작성자만 삭제할 수 있습니다.' });
+    const user = await User.findOne({ _id: ObjectId(payload) });
+
+    if (user.type !== 'admin') {
+      if (!comment.user._id.equals(ObjectId(payload))) {
+        return res.status(400).send({ message: '댓글 작성자만 삭제할 수 있습니다.' });
+      }
     }
+
     if (postType === 'recipes') {
       await Promise.all([
         Comment.deleteOne({ _id: ObjectId(commentId) }),

--- a/server/controller/diet/deletePost.js
+++ b/server/controller/diet/deletePost.js
@@ -1,3 +1,4 @@
+const { User } = require('../../models/user');
 const { Diet } = require('../../models/diet');
 const { Comment } = require('../../models/comment');
 const { Like } = require('../../models/like');
@@ -26,8 +27,12 @@ module.exports = async (req, res) => {
       return res.status(400).send({ message: '존재하지 않는 게시물입니다.' });
     }
 
-    if (!diet.user._id.equals(ObjectId(payload))) {
-      return res.status(400).send({ message: '게시물의 작성자만 삭제할 수 있습니다' });
+    const user = await User.findOne({ _id: ObjectId(payload) });
+
+    if (user.type !== 'admin') {
+      if (!diet.user._id.equals(ObjectId(payload))) {
+        return res.status(400).send({ message: '게시물의 작성자만 삭제할 수 있습니다' });
+      }
     }
 
     await Promise.all([
@@ -36,7 +41,7 @@ module.exports = async (req, res) => {
       Like.deleteMany({ post: id }),
       Bookmark.deleteMany({ post: id }),
     ]);
-    return res.status(200).send({ message: '해당 식단 삭제하였습니다.' });
+    return res.status(200).send({ message: '해당 식단을 삭제하였습니다.' });
   } catch (err) {
     return res.status(500).send({ message: err.message });
   }

--- a/server/controller/recipe/deletePost.js
+++ b/server/controller/recipe/deletePost.js
@@ -1,3 +1,4 @@
+const { User } = require('../../models/user');
 const { Recipe } = require('../../models/recipe');
 const { Comment } = require('../../models/comment');
 const { Like } = require('../../models/like');
@@ -22,8 +23,16 @@ module.exports = async (req, res) => {
 
     const recipe = await Recipe.findOne({ _id: id });
 
-    if (!recipe.user._id.equals(ObjectId(payload))) {
-      return res.status(400).send({ message: '게시물의 작성자만 삭제할 수 있습니다' });
+    if (!recipe) {
+      return res.status(400).send({ message: '존재하지 않는 게시물입니다.' });
+    }
+
+    const user = await User.findOne({ _id: ObjectId(payload) });
+
+    if (user.type !== 'admin') {
+      if (!recipe.user._id.equals(ObjectId(payload))) {
+        return res.status(400).send({ message: '게시물의 작성자만 삭제할 수 있습니다' });
+      }
     }
 
     await Promise.all([

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -48,11 +48,13 @@ module.exports = (req, res) => {
         await user.save();
 
         return res.status(200).send({
-          user: {
-            type: user._type,
-            image_url: user.image_url,
-            nickname: user.nickname,
-            email: user.email,
+          data: {
+            user: {
+              type: user.type,
+              image_url: user.image_url,
+              nickname: user.nickname,
+              email: user.email,
+            },
           },
           message: '로그인에 성공하였습니다.',
         });


### PR DESCRIPTION
## 관리자 권한 추가 부분
- 유저 타입이 admin일 때, 게시글 삭제와 댓글 삭제가 가능하도록 하였음

## 로그인 응답 시 유저 정보 전달 부분
![Screenshot from 2021-09-29 14-43-07](https://user-images.githubusercontent.com/68040092/135209936-e1808537-c120-4315-a508-da8ac8973bf8.png)

## 그 외
- README.md 수정
  - 서버 flow chart 수정본 적용
  - 사용 스택 변경점 적용