### PR TITLE
[Server] cookie 관련 설정 변경

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -29,17 +29,18 @@ const server = async () => {
     // mongoose.set('debug', true); // mongodb 쿼리문 디버깅 확인용 코드
     console.log('mongodb connected');
 
-    app.use(express.json());
-    app.use(express.urlencoded({ extended: true }));
-    app.use(cookieParser());
     app.use(
       cors({
         // CORS 설정
-        origin: true,
+        origin: true, // 클라이언트 도메인 주소가 자동으로 추가됨. 와일드카드와는 다름.
         credentials: true,
         methods: ['GET', 'POST', 'OPTIONS', 'PATCH', 'DELETE'],
       }),
     );
+
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: true }));
+    app.use(cookieParser());
 
     app.get('/', (req, res) => {
       res.send('Hello Server!');

--- a/server/app.js
+++ b/server/app.js
@@ -35,7 +35,7 @@ const server = async () => {
     app.use(
       cors({
         // CORS 설정
-        origin: ['http://localhost', 'http://localhost:2000', 'https://menuger.shop'],
+        origin: true,
         credentials: true,
         methods: ['GET', 'POST', 'OPTIONS', 'PATCH', 'DELETE'],
       }),

--- a/server/app.js
+++ b/server/app.js
@@ -3,8 +3,8 @@ const express = require('express');
 const cookieParser = require('cookie-parser');
 const app = express();
 const cors = require('cors');
-// const port = process.env.PORT || 3000;
-const port = 3000;
+const port = process.env.PORT || 3000;
+// const port = 80;
 const mongoose = require('mongoose');
 const {
   userRouter,

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -37,11 +37,13 @@ module.exports = (req, res) => {
           httpOnly: true,
           secure: true,
           sameSite: 'None',
+          domain: 'https://menuger.shop',
         });
         res.cookie('refreshToken', refreshToken, {
           httpOnly: true,
           secure: true,
           sameSite: 'None',
+          domain: 'https://menuger.shop',
         });
 
         user.refreshToken = refreshToken;

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -37,11 +37,13 @@ module.exports = (req, res) => {
           httpOnly: true,
           secure: true,
           sameSite: 'None',
+          domain: '.menuger.shop',
         });
         res.cookie('refreshToken', refreshToken, {
           httpOnly: true,
           secure: true,
           sameSite: 'None',
+          domain: '.menuger.shop',
         });
 
         user.refreshToken = refreshToken;

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -37,13 +37,11 @@ module.exports = (req, res) => {
           httpOnly: true,
           secure: true,
           sameSite: 'None',
-          domain: 'menuger.shop',
         });
         res.cookie('refreshToken', refreshToken, {
           httpOnly: true,
           secure: true,
           sameSite: 'None',
-          domain: 'menuger.shop',
         });
 
         user.refreshToken = refreshToken;

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -35,15 +35,15 @@ module.exports = (req, res) => {
 
         res.cookie('accessToken', accessToken, {
           httpOnly: true,
-          secure: true,
-          sameSite: 'None',
-          domain: '.menuger.shop',
+          // secure: true,
+          // sameSite: 'None',
+          // domain: '.menuger.shop',
         });
         res.cookie('refreshToken', refreshToken, {
           httpOnly: true,
-          secure: true,
-          sameSite: 'None',
-          domain: '.menuger.shop',
+          // secure: true,
+          // sameSite: 'None',
+          // domain: '.menuger.shop',
         });
 
         user.refreshToken = refreshToken;

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -37,13 +37,13 @@ module.exports = (req, res) => {
           httpOnly: true,
           secure: true,
           sameSite: 'None',
-          domain: 'https://menuger.shop',
+          domain: 'menuger.shop',
         });
         res.cookie('refreshToken', refreshToken, {
           httpOnly: true,
           secure: true,
           sameSite: 'None',
-          domain: 'https://menuger.shop',
+          domain: 'menuger.shop',
         });
 
         user.refreshToken = refreshToken;

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -37,13 +37,11 @@ module.exports = (req, res) => {
           httpOnly: true,
           secure: true,
           sameSite: 'None',
-          domain: '.menuger.shop',
         });
         res.cookie('refreshToken', refreshToken, {
           httpOnly: true,
           secure: true,
           sameSite: 'None',
-          domain: '.menuger.shop',
         });
 
         user.refreshToken = refreshToken;

--- a/server/controller/user/signinKakao.js
+++ b/server/controller/user/signinKakao.js
@@ -63,24 +63,19 @@ module.exports = async (req, res) => {
       }
     });
 
-    res.cookie('kakao_login', 'success', {
-      maxAge,
-      httpOnly: true,
-      secure: true,
-      sameSite: 'None',
-    });
-    res.cookie('email', email, { maxAge, httpOnly: true, secure: true, sameSite: 'None' });
-    res.cookie('nickname', nickname, { maxAge, httpOnly: true, secure: true, sameSite: 'None' });
-    res.cookie('image_url', image_url, { maxAge, httpOnly: true, secure: true, sameSite: 'None' });
+    res.cookie('kakao_login', 'success', { maxAge });
+    res.cookie('email', email, { maxAge });
+    res.cookie('nickname', nickname, { maxAge });
+    res.cookie('image_url', image_url, { maxAge });
     res.cookie('kakaoAccessToken', data.access_token, {
       httpOnly: true,
-      secure: true,
-      sameSite: 'None',
+      // secure: true,
+      // sameSite: 'None',
     });
     res.cookie('kakaoRefreshToken', data.refresh_token, {
       httpOnly: true,
-      secure: true,
-      sameSite: 'None',
+      // secure: true,
+      // sameSite: 'None',
     });
     res.redirect(process.env.SITE_DOMAIN);
   } catch (err) {

--- a/server/controller/user/signinKakao.js
+++ b/server/controller/user/signinKakao.js
@@ -8,26 +8,39 @@ module.exports = async (req, res) => {
   const { code } = req.query;
 
   try {
-    const { data } = await axios.post('https://kauth.kakao.com/oauth/token', null, {
-      params: {
-        grant_type: 'authorization_code',
-        client_id: process.env.CLIENT_ID,
-        redirect_uri: process.env.REDIRECT_URI,
-        code,
+    const { data } = await axios.post(
+      'https://kauth.kakao.com/oauth/token',
+      null,
+      {
+        params: {
+          grant_type: 'authorization_code',
+          client_id: process.env.CLIENT_ID,
+          redirect_uri: process.env.REDIRECT_URI,
+          code,
+        },
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
       },
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
+      {
+        withCredentials: true,
       },
-    });
+    );
 
     const {
       data: { kakao_account },
-    } = await axios.get('https://kapi.kakao.com/v2/user/me', {
-      headers: {
-        Authorization: `Bearer ${data.access_token}`,
-        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+    } = await axios.get(
+      'https://kapi.kakao.com/v2/user/me',
+      {
+        headers: {
+          Authorization: `Bearer ${data.access_token}`,
+          'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+        },
       },
-    });
+      {
+        withCredentials: true,
+      },
+    );
 
     const {
       email,

--- a/server/controller/utils/checktoken.js
+++ b/server/controller/utils/checktoken.js
@@ -31,6 +31,9 @@ module.exports = {
                 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
               },
             },
+            {
+              withCredentials: true,
+            },
           );
           if (expires_in <= 0) {
             const { access_token, refresh_token = null } = await axios.post(
@@ -44,6 +47,9 @@ module.exports = {
                 headers: {
                   'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
                 },
+              },
+              {
+                withCredentials: true,
               },
             );
 


### PR DESCRIPTION
## cookie 관련 옵션 설정
- secure, sameSite, domain 옵션을 주었음
  - 로컬에서는 쓰지 못하는 옵션이기 때문에 PR단계에서는 주석처리를 진행하였음
- 카카오 로그인 시 cookie도 client에서의 접근을 위해 email, nickname, image_url의 옵션들을 삭제하고, maxage만 남겨놓았음
- 카카오 엑세스토큰, 리프래시토큰은 secure, sameSite옵션을 주었지만, 로컬에서의 원활한 테스트를 위해 주석처리하였음

## 그 외
- axios 요청에 대해 withCredentials 옵션을 주었음
- CORS origin을 변경하였음