### PR TITLE
[Server] Fix: 로그인, 식단/레시피작성 로직 수정

### DIFF
--- a/server/controller/diet/createPost.js
+++ b/server/controller/diet/createPost.js
@@ -19,7 +19,7 @@ module.exports = async (req, res) => {
     }
 
     const user = await User.findById(ObjectId(payload));
-    const { title, subtitle, content, hashtags = [] } = req.body;
+    const { title, subtitle, content, hashtags = [], dietColumnList = [] } = req.body;
 
     const post = new Diet({
       title,
@@ -27,9 +27,12 @@ module.exports = async (req, res) => {
       content,
       user,
       hashtags,
+      dietColumnList,
     });
     await post.save();
-    return res.status(201).send({ message: '식단 작성이 완료되었습니다.' });
+    return res
+      .status(201)
+      .send({ data: { postId: post._id }, message: '식단 작성이 완료되었습니다.' });
   } catch (err) {
     return res.status(500).send({ message: err.message });
   }

--- a/server/controller/recipe/createPost.js
+++ b/server/controller/recipe/createPost.js
@@ -21,16 +21,20 @@ module.exports = async (req, res) => {
     const user = await User.findById(ObjectId(payload));
     const { title, content, images = [], hashtags = [] } = req.body;
 
-    await new Recipe({
+    const post = new Recipe({
       title,
       content,
       user,
       hashtags,
       thumbnail_url: images.length ? images[0].imageKey : null,
       originalFileName: images.length ? images[0].originalname : null,
-    }).save();
+    });
 
-    return res.status(201).send({ message: '레시피 작성이 완료되었습니다.' });
+    await post.save();
+
+    return res
+      .status(201)
+      .send({ data: { postId: post._id }, message: '레시피 작성이 완료되었습니다.' });
   } catch (err) {
     return res.status(500).send({ message: err.message });
   }

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -35,31 +35,35 @@ module.exports = (req, res) => {
 
         res.cookie('accessToken', accessToken, {
           httpOnly: true,
-          secure: true,
-          sameSite: 'None',
-          domain: '.menuger.shop',
+          // secure: true,
+          // sameSite: 'None',
+          // domain: '.menuger.shop',
         });
         res.cookie('refreshToken', refreshToken, {
           httpOnly: true,
-          secure: true,
-          sameSite: 'None',
-          domain: '.menuger.shop',
+          // secure: true,
+          // sameSite: 'None',
+          // domain: '.menuger.shop',
         });
 
         user.refreshToken = refreshToken;
         await user.save();
 
-        return res.status(200).send({
-          data: {
-            user: {
-              type: user.type,
-              image_url: user.image_url,
-              nickname: user.nickname,
-              email: user.email,
+        return res
+          .clearCookie('kakaoAccessToken')
+          .clearCookie('kakaoRefreshToken')
+          .status(200)
+          .send({
+            data: {
+              user: {
+                type: user.type,
+                image_url: user.image_url,
+                nickname: user.nickname,
+                email: user.email,
+              },
             },
-          },
-          message: '로그인에 성공하였습니다.',
-        });
+            message: '로그인에 성공하였습니다.',
+          });
       });
     });
   } catch (err) {

--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -35,15 +35,15 @@ module.exports = (req, res) => {
 
         res.cookie('accessToken', accessToken, {
           httpOnly: true,
-          // secure: true,
-          // sameSite: 'None',
-          // domain: '.menuger.shop',
+          secure: true,
+          sameSite: 'None',
+          domain: '.menuger.shop',
         });
         res.cookie('refreshToken', refreshToken, {
           httpOnly: true,
-          // secure: true,
-          // sameSite: 'None',
-          // domain: '.menuger.shop',
+          secure: true,
+          sameSite: 'None',
+          domain: '.menuger.shop',
         });
 
         user.refreshToken = refreshToken;

--- a/server/controller/user/signinKakao.js
+++ b/server/controller/user/signinKakao.js
@@ -69,13 +69,15 @@ module.exports = async (req, res) => {
     res.cookie('image_url', image_url, { maxAge });
     res.cookie('kakaoAccessToken', data.access_token, {
       httpOnly: true,
-      // secure: true,
-      // sameSite: 'None',
+      secure: true,
+      sameSite: 'None',
+      domain: '.menuger.shop',
     });
     res.cookie('kakaoRefreshToken', data.refresh_token, {
       httpOnly: true,
-      // secure: true,
-      // sameSite: 'None',
+      secure: true,
+      sameSite: 'None',
+      domain: '.menuger.shop',
     });
     res.redirect(process.env.SITE_DOMAIN);
   } catch (err) {

--- a/server/controller/user/signinKakao.js
+++ b/server/controller/user/signinKakao.js
@@ -69,16 +69,17 @@ module.exports = async (req, res) => {
     res.cookie('image_url', image_url, { maxAge });
     res.cookie('kakaoAccessToken', data.access_token, {
       httpOnly: true,
-      secure: true,
-      sameSite: 'None',
-      domain: '.menuger.shop',
+      // secure: true,
+      // sameSite: 'None',
+      // domain: '.menuger.shop',
     });
     res.cookie('kakaoRefreshToken', data.refresh_token, {
       httpOnly: true,
-      secure: true,
-      sameSite: 'None',
-      domain: '.menuger.shop',
+      // secure: true,
+      // sameSite: 'None',
+      // domain: '.menuger.shop',
     });
+    res.clearCookie('accessToken').clearCookie('refreshToken');
     res.redirect(process.env.SITE_DOMAIN);
   } catch (err) {
     res.cookie('kakao_login', 'fail', { maxAge });


### PR DESCRIPTION
## 로그인 부분
- 서비스 자체 로그인 시 카카오 로그인 관련 쿠키 제거
- 카카오 로그인 시,  서비스 자체 로그인 쿠키 제거

## 식단 부분
- 게시글 작성 요청 시 dietColumnList로 받아서 값이 담기게 수정

## 레시피/식단 공통 부분
- 정상적으로 작성 완료 시, 응답에 해당 게시물 id를 담아서 보내게 수정

![Screenshot from 2021-10-01 12-03-29](https://user-images.githubusercontent.com/68040092/135559453-e433a86c-b050-44fa-936c-677b70513547.png)

