### PR TITLE
[Client] Feat: 레시피 페이지 개선(WIP)

### DIFF
--- a/client/src/components/auth/Signin.js
+++ b/client/src/components/auth/Signin.js
@@ -140,6 +140,7 @@ const Signin = ({ handleMenuClick, hideModal }) => {
         },
       );
       if (status === 200) {
+        hideModal();
         const userInfo = {
           email: user.email,
           image_url: user.image_url,
@@ -148,7 +149,6 @@ const Signin = ({ handleMenuClick, hideModal }) => {
           type: user.type,
         };
         addMessage({ message: '로그인 성공', delay: 500 }, () => {
-          hideModal();
           dispatch(setUserInfo(userInfo));
           history.push('/');
         });

--- a/client/src/components/auth/Signup.js
+++ b/client/src/components/auth/Signup.js
@@ -63,7 +63,7 @@ const LoginLink = styled.span`
   }
 `;
 
-const Signup = ({ handleMenuClick }) => {
+const Signup = ({ handleMenuClick, hideModal }) => {
   const [isValidPwd, setIsValidPwd] = useState(false);
   const [disabled, setDisabled] = useState(false);
 
@@ -105,7 +105,8 @@ const Signup = ({ handleMenuClick }) => {
       });
 
       if (status === 201) {
-        addMessage({ message }, () => {
+        hideModal();
+        addMessage({ message, delay: 1000 }, () => {
           handleMenuClick('signin');
         });
       } else {

--- a/client/src/components/common/cards/CardItem.js
+++ b/client/src/components/common/cards/CardItem.js
@@ -106,8 +106,6 @@ const CardItem = ({
   bookmarksCount,
   hashtags,
 }) => {
-  console.log(user);
-
   return (
     <CardContainer>
       <Header>

--- a/client/src/components/common/cards/CardList.js
+++ b/client/src/components/common/cards/CardList.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import CardItem from './CardItem';
 import svgToComponent from '../../../utils/svg';
 import scrollToTop from '../../../utils/scroll';
+import { HiOutlineArrowCircleUp } from 'react-icons/hi';
 
 const Wrapper = styled.div`
   overflow-x: hidden;
@@ -20,10 +21,24 @@ const CardListContainer = styled.ul`
 const ScrollEnd = styled.div`
   display: flex;
   justify-content: center;
+  height: 70px;
+`;
+
+const ScrollToTop = styled.div`
+  position: fixed;
+  z-index: 200;
+  right: 10px;
+  bottom: 10px;
+  font-size: 50px;
+  color: #ffc436;
+  :hover {
+    color: #fc9f77;
+    cursor: pointer;
+  }
 `;
 
 const CardList = forwardRef(({ cards, hasNext }, fetchMoreRef) => {
-  const arrowDownConfig = { svgName: 'arrowDown' };
+  const arrowDownConfig = { svgName: 'arrowDown', props: { width: 200 } };
   const arrowUpConfig = { svgName: 'arrowUp', props: { onClick: scrollToTop, cursor: 'pointer' } };
 
   return (
@@ -49,7 +64,10 @@ const CardList = forwardRef(({ cards, hasNext }, fetchMoreRef) => {
       </Wrapper>
       <ScrollEnd ref={fetchMoreRef}>
         {hasNext && cards.length > 0 && svgToComponent(arrowDownConfig)}
-        {!hasNext && svgToComponent(arrowUpConfig)}
+        {/*!hasNext && svgToComponent(arrowUpConfig)} */}
+        <ScrollToTop onClick={scrollToTop}>
+          <HiOutlineArrowCircleUp />
+        </ScrollToTop>
       </ScrollEnd>
     </>
   );

--- a/client/src/components/common/modal/Modal.js
+++ b/client/src/components/common/modal/Modal.js
@@ -31,7 +31,7 @@ const ModalContainer = styled.div`
   border-radius: 10px;
   background: white;
   z-index: 10;
-  overflow-y: auto;
+  overflow-y: hidden;
   box-shadow: 1px 3px 3px 1px rgba(0, 0, 0, 0.2);
   animation: slideIn 0.3s linear;
   @media screen and (max-width: 768px) {
@@ -62,6 +62,7 @@ const CloseBtn = styled.div`
 
 const Content = styled.div`
   height: 100%;
+  overflow-y: auto;
 `;
 
 const Modal = ({ children, hideModal, style }) => {

--- a/client/src/components/header/LeftContainer.js
+++ b/client/src/components/header/LeftContainer.js
@@ -7,7 +7,7 @@ import logoTextTwoLine from '../../utils/logoImage/logoTextTwoLine.png';
 
 const StyledLink = styled(NavLink)`
   text-decoration: none !important;
-  color: black;
+  color: #3c4043;
   &:hover {
     color: #ffc436;
     cursor: pointer;

--- a/client/src/components/header/RightContainer.js
+++ b/client/src/components/header/RightContainer.js
@@ -88,6 +88,7 @@ const Container = styled.div`
   justify-content: center;
   & > div {
     cursor: pointer;
+    color: #3c4043;
     &:hover {
       color: #ffc436;
     }
@@ -224,7 +225,9 @@ const RightContainer = ({
   return (
     <>
       <ModalContainer>
-        {modalContent === 'signup' && <Signup handleMenuClick={handleMenuClick} />}
+        {modalContent === 'signup' && (
+          <Signup handleMenuClick={handleMenuClick} hideModal={hideModal} />
+        )}
         {modalContent === 'signin' && (
           <Signin handleMenuClick={handleMenuClick} hideModal={hideModal} />
         )}

--- a/client/src/components/header/SearchContainer.js
+++ b/client/src/components/header/SearchContainer.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import axios from 'axios';
 
@@ -6,7 +6,7 @@ const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  border: solid 2px;
+  border: solid 2px #3c4043;
   height: 40px;
   &:focus-within {
     border: 2px solid #ffc436;
@@ -27,6 +27,7 @@ const Container = styled.div`
   select {
     background-color: white;
     padding-left: 1em;
+    color: #3c4043;
   }
   @media screen and (max-width: 768px) {
     display: none;

--- a/client/src/pages/RecipeEditPage.js
+++ b/client/src/pages/RecipeEditPage.js
@@ -7,6 +7,7 @@ import RecipeEditor from '../components/recipe_edit/RecipeEditor';
 import useToast from '../hooks/toast/useToast';
 import StandardButton from '../components/common/buttons/StandardButton';
 import HashTagEditor from '../components/common/HashtagEditor';
+import extractThumbnailKey from '../utils/thumbnail';
 
 const { REACT_APP_MOBILE_WIDTH, REACT_APP_WEB_MAX_WIDTH } = process.env;
 
@@ -67,7 +68,15 @@ const RecipeEditPage = () => {
       addMessage({ mode: 'info', message: '본문을 입력해주세요', delay: 1000 });
       return;
     }
+
+    const thumbnailImage =
+      images?.filter(image => image.imageKey === extractThumbnailKey(recipeContent)) || [];
+
+    thumbnailImage.forEach(
+      image => (image.imageKey = `${process.env.REACT_APP_S3_URL}/raw/${image.imageKey}`),
+    );
     setDisabled(true);
+
     try {
       const {
         data: {
@@ -78,7 +87,7 @@ const RecipeEditPage = () => {
       } = await axios.post(
         `${process.env.REACT_APP_ENDPOINT_URL}/recipes`,
         {
-          images,
+          images: thumbnailImage,
           title,
           content: recipeContent,
           hashtags: tagList,

--- a/client/src/pages/RecipePage.js
+++ b/client/src/pages/RecipePage.js
@@ -52,7 +52,10 @@ const RecipePage = () => {
         sort: sortOptionMapper[idx],
       },
     });
-    console.log(recipes);
+    if (page === 1 && recipes.length < 12) {
+      //return setHasNext(false);
+    }
+
     if (!recipes.length) {
       return setHasNext(false);
     }

--- a/client/src/styles/GlobalStyles.js
+++ b/client/src/styles/GlobalStyles.js
@@ -7,6 +7,23 @@ const GlobalStyle = createGlobalStyle`
     * {
         box-sizing: border-box;
     };
+
+    *::-webkit-scrollbar {
+        width: 10px;
+    }
+
+    *::-webkit-scrollbar-track {
+        background: #f1f1f1; 
+    }
+
+    *::-webkit-scrollbar-thumb {
+        background: #888;
+        border-radius: 5px;
+    }
+
+    *::-webkit-scrollbar-thumb:hover {
+        background: #555; 
+    }
 `;
 
 export default GlobalStyle;

--- a/client/src/utils/thumbnail.js
+++ b/client/src/utils/thumbnail.js
@@ -1,8 +1,10 @@
-const extractThumbnail = str => {
-  const regex = /<img.+src=(?:"|')(.+?)(?:"|')(?:.+?)>/;
+const extractThumbnailKey = str => {
+  const regex = /<img.+src=[\s\S][^\s]+/;
   const thumbnail = regex.exec(str);
 
-  return thumbnail ? thumbnail[1] : null;
+  return thumbnail?.[0]
+    .replace('<img src=', '')
+    .replace(`${process.env.REACT_APP_S3_URL}/raw/`, '');
 };
 
-export default extractThumbnail;
+export default extractThumbnailKey;

--- a/server/models/recipe.js
+++ b/server/models/recipe.js
@@ -12,7 +12,7 @@ const recipeSchema = new Schema(
       _id: { type: ObjectId, ref: 'user', required: true },
       email: { type: String, required: true },
       nickname: { type: String, required: true },
-      image_url: { type: String, required: true },
+      image_url: { type: String },
     },
     commentsCount: { type: Number, default: 0 },
     likesCount: { type: Number, default: 0 },


### PR DESCRIPTION
## 작업 내용
- 로그인/회원가입 직후 모달 바로 사라지도록 수정 + toast가 좀 더 빨리 사라지도록 개선
- 스크롤이 모달 내부에 생기도록 수정 + 스크롤 디자인 변경
  - ubuntu에서 스크롤이 너무 투박하게 생겨서 수정하는 것이 목적이었는데, mac에도 영향이 가는지 확인해야 할 것 같습니다.
- editor 본문에서 최상단의 이미지를 추출할 수 있도록 수정
- 레시피 스키마에서 user의 image_url required option을 제거하여 빈 문자열을 허용하도록 수정