### PR TITLE
[Client] Design/Refactor: 해시정보 컴포넌트 재사용화, 모달 모바일 기준 UI 개선

### DIFF
--- a/client/src/components/common/cards/CardItem.js
+++ b/client/src/components/common/cards/CardItem.js
@@ -63,9 +63,19 @@ const Info = styled.div`
   padding: 0 3%;
 `;
 
-const UserTagInfoWrapper = styled.div`
+const UserInfoWrapper = styled.div`
   width: 60%;
   padding-bottom: 0.5rem;
+`;
+
+const HashtagInfoWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  margin-top: auto;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 15%;
+  border-top: 1px solid #e4e4e4;
 `;
 
 const Border = styled.div`
@@ -124,7 +134,7 @@ const CardItem = ({
         </Figure>
       </Wrapper>
       <Info>
-        <UserTagInfoWrapper>
+        <UserInfoWrapper>
           <UserInfo
             handleCardClick={() => handleCardClick(postId)}
             image_url={user.image_url}
@@ -132,14 +142,16 @@ const CardItem = ({
             title={title}
             updatedAt={updatedAt}
           />
-        </UserTagInfoWrapper>
+        </UserInfoWrapper>
         <PostInfo>
           <BookmarkButton number={bookmarksCount} />
           <LikeButton number={likesCount} />
           <CommentMark number={commentsCount} />
         </PostInfo>
       </Info>
-      <HashtagInfo hashtags={hashtags} />
+      <HashtagInfoWrapper>
+        <HashtagInfo hashtags={hashtags} />
+      </HashtagInfoWrapper>
       <Border className="shadow" />
     </CardContainer>
   );

--- a/client/src/components/common/cards/HashtagInfo.js
+++ b/client/src/components/common/cards/HashtagInfo.js
@@ -1,42 +1,36 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const Wrapper = styled.div`
-  width: 100%;
-  display: flex;
-  margin-top: auto;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  padding: 0.5rem 15%;
-  border-top: 1px solid #e4e4e4;
-`;
-
 const Hashtag = styled.div`
-  color: #4a90e2;
-  font-size: 0.7rem;
+  color: ${({ color }) => color || '#4a90e2'};
+  font-size: ${({ fs }) => fs || '0.7rem'};
   @media (max-width: 1200px) {
-    font-size: 0.9rem;
+    font-size: ${({ fs1200 }) => fs1200 || '0.9rem'};
   }
   @media (max-width: 900px) {
-    font-size: 1.1rem;
+    font-size: ${({ fs900 }) => fs900 || '1.1rem'};
   }
   @media (max-width: 768px) {
-    font-size: 3.6vw;
+    font-size: ${({ fs768 }) => fs768 || '3.6vw'};
   }
   &:hover {
     cursor: pointer;
   }
 `;
 
-const HashtagInfo = ({ hashtags }) => {
+const HashtagInfo = ({ hashtags, style = {} }) => {
+  const { fs, fs1200, fs900, fs768, color } = style;
+
   return (
     <>
       {!!hashtags.length && (
-        <Wrapper>
+        <>
           {hashtags.map((hashtag, idx) => (
-            <Hashtag key={idx}>#{hashtag}</Hashtag>
+            <Hashtag key={idx} fs={fs} fs1200={fs1200} fs900={fs900} fs768={fs768} color={color}>
+              #{hashtag}
+            </Hashtag>
           ))}
-        </Wrapper>
+        </>
       )}
     </>
   );

--- a/client/src/components/common/modal/Modal.js
+++ b/client/src/components/common/modal/Modal.js
@@ -37,6 +37,7 @@ const ModalContainer = styled.div`
   @media screen and (max-width: 768px) {
     width: 100%;
     min-width: 100%;
+    padding: 3rem 0;
   }
   @keyframes slideIn {
     0% {


### PR DESCRIPTION
## 작업내용
- 모바일 너비일 때 모달 콘텐츠 양 옆의 padding을 제거
- 해시태그 정보 컴포넌트를 재사용 가능하도록 wrapper를 분리 및 props 정보를 반영해 styling 가능하도록 수정