### PR TITLE
[Client] Fix: 레시피 페이지 기능개선 및 오류 수정 + 다크모드 적용할 수 있도록 기본 설정 추가

### DIFF
--- a/client/src/components/common/buttons/PostInfoButton.js
+++ b/client/src/components/common/buttons/PostInfoButton.js
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: fit-content;
+  &:hover {
+    cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  }
+  & > svg {
+    fill: ${({ active }) => active && '#ffcd36'};
+    &:hover {
+      fill: ${({ active }) => (active ? '#ffe69a' : '#b3b3b3')};
+    }
+  }
+`;
+
+const Counter = styled.div`
+  text-align: center;
+  @media (max-width: 768px) {
+    font-size: 5vw;
+  }
+`;
+
+const PostInfoButton = ({ children, onClick, active, disabled, count, num }) => {
+  return (
+    <Wrapper onClick={onClick} active={active} disabled={disabled}>
+      {children}
+      {count >= 0 && <Counter>{num}</Counter>}
+    </Wrapper>
+  );
+};
+
+export default PostInfoButton;

--- a/client/src/components/common/cards/CardItem.js
+++ b/client/src/components/common/cards/CardItem.js
@@ -1,3 +1,4 @@
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import BookmarkButton from '../buttons/BookmarkButton';
@@ -12,7 +13,14 @@ const CardContainer = styled.li`
   display: flex;
   flex-direction: column;
   margin-bottom: 2rem;
-  gap: 0.5rem;
+  //gap: 0.5rem;
+  transition: 0.3s;
+  background-color: ${({ isDark }) => isDark && 'white'};
+
+  &:hover {
+    transform: translateY(-0.7rem);
+    transition: 0.3s;
+  }
   &:hover > div.shadow {
     box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
   }
@@ -33,6 +41,9 @@ const Wrapper = styled.div`
   overflow: hidden;
   border-top-right-radius: 7px;
   border-top-left-radius: 7px;
+  &:nth-child(1) {
+    margin-bottom: 0.5rem;
+  }
 `;
 
 const Figure = styled.figure`
@@ -61,6 +72,7 @@ const Info = styled.div`
   display: flex;
   flex-wrap: wrap;
   padding: 0 3%;
+  background-color: ${({ isDark }) => isDark && 'white'};
 `;
 
 const UserInfoWrapper = styled.div`
@@ -76,6 +88,9 @@ const HashtagInfoWrapper = styled.div`
   flex-wrap: wrap;
   padding: 0.5rem 15%;
   border-top: 1px solid #e4e4e4;
+  background-color: ${({ isDark }) => isDark && 'white'};
+  border-bottom-right-radius: 5px;
+  border-bottom-left-radius: 5px;
 `;
 
 const Border = styled.div`
@@ -90,12 +105,10 @@ const Border = styled.div`
   border-top-left-radius: 7px;
   border-radius: 7px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transition: ${({ isDark }) => !isDark && 'all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1)'};
+  background-color: ${({ isDark }) => isDark && 'white'};
   @media (max-width: 768px) {
     margin: 0;
-  }
-  &:hover {
-    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
   }
 `;
 
@@ -108,7 +121,7 @@ const PostInfo = styled.div`
 
 const CardItem = ({
   postId,
-  postType = 'recipe',
+  postType,
   title,
   thumbnail_url,
   originalFileName,
@@ -120,6 +133,8 @@ const CardItem = ({
   updatedAt,
   handleCardClick,
 }) => {
+  const { isDarkMode } = useSelector(state => state.theme);
+
   return (
     <CardContainer>
       <Wrapper>
@@ -133,8 +148,8 @@ const CardItem = ({
           <Img src={thumbnail_url} alt={originalFileName} />
         </Figure>
       </Wrapper>
-      <Info>
-        <UserInfoWrapper>
+      <Info isDark={isDarkMode}>
+        <UserInfoWrapper isDark={isDarkMode}>
           <UserInfo
             handleCardClick={() => handleCardClick(postId)}
             image_url={user.image_url}
@@ -143,18 +158,18 @@ const CardItem = ({
             updatedAt={updatedAt}
           />
         </UserInfoWrapper>
-        <PostInfo>
+        <PostInfo isDark={isDarkMode}>
           <BookmarkButton number={bookmarksCount} />
           <LikeButton number={likesCount} />
           <CommentMark number={commentsCount} />
         </PostInfo>
       </Info>
       {!!hashtags.length && (
-        <HashtagInfoWrapper>
+        <HashtagInfoWrapper isDark={isDarkMode}>
           <HashtagInfo hashtags={hashtags} />
         </HashtagInfoWrapper>
       )}
-      <Border className="shadow" />
+      <Border className="shadow" isDark={isDarkMode} />
     </CardContainer>
   );
 };

--- a/client/src/components/common/cards/CardList.js
+++ b/client/src/components/common/cards/CardList.js
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import styled from 'styled-components';
+import { useSelector } from 'react-redux';
 
 import CardItem from './CardItem';
 import svgToComponent from '../../../utils/svg';
@@ -8,6 +9,7 @@ import { HiOutlineArrowCircleUp } from 'react-icons/hi';
 
 const Wrapper = styled.div`
   overflow-x: hidden;
+  //background-color: ${({ isDark }) => isDark && 'white'};
 `;
 
 const CardListContainer = styled.ul`
@@ -22,7 +24,7 @@ const CardListContainer = styled.ul`
 const ScrollEnd = styled.div`
   display: flex;
   justify-content: center;
-  height: 70px;
+  height: 0px;
 `;
 
 const ScrollToTop = styled.div`
@@ -38,12 +40,20 @@ const ScrollToTop = styled.div`
   }
 `;
 
+const EmptyDiv = styled.div`
+  height: 70px;
+`;
+
 const CardList = forwardRef(({ cards, hasNext, handleCardClick }, fetchMoreRef) => {
-  const arrowDownConfig = { svgName: 'arrowDown', props: { width: 200 } };
+  const { isDarkMode } = useSelector(state => state.theme);
+  const arrowDownConfig = {
+    svgName: 'arrowDown',
+    props: { width: 200, fill: isDarkMode ? 'white' : 'black' },
+  };
 
   return (
     <>
-      <Wrapper>
+      <Wrapper isDark={isDarkMode}>
         <CardListContainer>
           {cards.map(card => (
             <CardItem
@@ -64,12 +74,15 @@ const CardList = forwardRef(({ cards, hasNext, handleCardClick }, fetchMoreRef) 
           ))}
         </CardListContainer>
       </Wrapper>
-      <ScrollEnd ref={fetchMoreRef}>
-        {hasNext && cards.length > 0 && svgToComponent(arrowDownConfig)}
-        <ScrollToTop onClick={scrollToTop}>
-          <HiOutlineArrowCircleUp />
-        </ScrollToTop>
-      </ScrollEnd>
+      {hasNext && (
+        <ScrollEnd ref={fetchMoreRef}>
+          {cards.length > 0 && svgToComponent(arrowDownConfig)}
+        </ScrollEnd>
+      )}
+      {!hasNext && <EmptyDiv />}
+      <ScrollToTop onClick={scrollToTop}>
+        <HiOutlineArrowCircleUp />
+      </ScrollToTop>
     </>
   );
 });

--- a/client/src/components/common/cards/CardList.js
+++ b/client/src/components/common/cards/CardList.js
@@ -9,7 +9,6 @@ import { HiOutlineArrowCircleUp } from 'react-icons/hi';
 
 const Wrapper = styled.div`
   overflow-x: hidden;
-  //background-color: ${({ isDark }) => isDark && 'white'};
 `;
 
 const CardListContainer = styled.ul`

--- a/client/src/components/header/Header.js
+++ b/client/src/components/header/Header.js
@@ -165,7 +165,6 @@ const Header = () => {
       <Switch>
         <Route exact path="/" component={LandingPage}></Route>
         <Route path="/recipes" component={RecipePage}></Route>
-        <Route path="/recipes?sort=dd" component={RecipePage}></Route>
         <Route path="/RecipeEditPage" component={RecipeEditPage}></Route>
         <Route path="/DietPage" component={DietPage}></Route>
         <Route path="/DietEditPage" component={DietEditPage}></Route>

--- a/client/src/components/header/Header.js
+++ b/client/src/components/header/Header.js
@@ -63,8 +63,6 @@ const HeaderContainer = styled.header`
   height: 80px;
   border-bottom: 1px solid;
   border-color: rgba(160, 160, 160, 0.25);
-  /* background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: saturate(80%) blur(30px); */
   background-color: white;
   display: flex;
   background-color: white;
@@ -167,6 +165,7 @@ const Header = () => {
       <Switch>
         <Route exact path="/" component={LandingPage}></Route>
         <Route path="/recipes" component={RecipePage}></Route>
+        <Route path="/recipes?sort=dd" component={RecipePage}></Route>
         <Route path="/RecipeEditPage" component={RecipeEditPage}></Route>
         <Route path="/DietPage" component={DietPage}></Route>
         <Route path="/DietEditPage" component={DietEditPage}></Route>

--- a/client/src/components/header/LeftContainer.js
+++ b/client/src/components/header/LeftContainer.js
@@ -43,7 +43,7 @@ const LeftContainer = () => {
         <img src={logoImageYellow} alt="로고 이미지"></img>
         <img src={logoTextTwoLine} alt="로고 텍스트"></img>
       </StyledLink>
-      <StyledLink to="/recipes">레시피</StyledLink>
+      <StyledLink to="/recipes?sort=dd">레시피</StyledLink>
       <StyledLink to="/DietPage">식단</StyledLink>
     </Container>
   );

--- a/client/src/components/header/RightContainer.js
+++ b/client/src/components/header/RightContainer.js
@@ -2,12 +2,12 @@ import { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { NavLink } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import axios from 'axios';
 
 import useModal from '../../hooks/useModal';
 import Signup from '../auth/Signup';
 import Signin from '../auth/Signin';
 import svgToComponent from '../../utils/svg';
+import useDarkToggle from '../../hooks/useDarkToggle';
 
 const StyledLink = styled(NavLink)`
   text-decoration: none !important;
@@ -268,6 +268,7 @@ const RightContainer = ({
   const userInfo = useSelector(state => state.user);
   const [modalContent, setModalContent] = useState('');
   const [userDropdown, setUserDropdown] = useState(false);
+  const DarkModeToggler = useDarkToggle();
   const { showModal, hideModal, ModalContainer } = useModal({
     width: 30,
     height: 70,
@@ -339,6 +340,7 @@ const RightContainer = ({
           </button>
         </WriteContainer>
       </Container>
+      <DarkModeToggler />
     </>
   );
 };

--- a/client/src/hooks/useDarkToggle.js
+++ b/client/src/hooks/useDarkToggle.js
@@ -1,0 +1,35 @@
+import { useSelector, useDispatch } from 'react-redux';
+import styled from 'styled-components';
+
+import { toggleTheme } from '../modules/theme';
+import { FiMoon, FiSun } from 'react-icons/fi';
+
+const SvgContainer = styled.div`
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  padding: 0.4rem;
+  &:hover {
+    cursor: pointer;
+    background-color: #eeeeee;
+  }
+`;
+
+const useDarkToggle = () => {
+  const { isDarkMode } = useSelector(state => state.theme);
+  const dispatch = useDispatch();
+
+  const handleToggle = () => dispatch(toggleTheme());
+
+  return () => (
+    <SvgContainer onClick={handleToggle}>
+      {!isDarkMode && <FiMoon size="100%" color="#333" strokeWidth="1.5" />}
+      {isDarkMode && <FiSun size="100%" color="#ffcd36" strokeWidth="1.5" />}
+    </SvgContainer>
+  );
+};
+
+export default useDarkToggle;

--- a/client/src/hooks/usePostInfoButton.js
+++ b/client/src/hooks/usePostInfoButton.js
@@ -1,28 +1,7 @@
 import { useState } from 'react';
-import styled from 'styled-components';
 
+import PostInfoButton from '../components/common/buttons/PostInfoButton';
 import useToast from '../hooks/toast/useToast';
-
-const Wrapper = styled.div`
-  width: 100%;
-  height: fit-content;
-  &:hover {
-    cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  }
-  & > svg {
-    fill: ${({ active }) => active && '#ffcd36'};
-    &:hover {
-      fill: ${({ active }) => (active ? '#ffe69a' : '#b3b3b3')};
-    }
-  }
-`;
-
-const Counter = styled.div`
-  text-align: center;
-  @media (max-width: 768px) {
-    font-size: 5vw;
-  }
-`;
 
 const usePostInfoButton = ({ postId, postType, active, count = -1 }) => {
   const [isActive, setIsActive] = useState(active);
@@ -54,12 +33,9 @@ const usePostInfoButton = ({ postId, postType, active, count = -1 }) => {
   };
 
   return ({ children }) => (
-    <Wrapper onClick={toggle} active={isActive} disabled={loading} count={count}>
-      <>
-        {children}
-        {count >= 0 && <Counter>{num}</Counter>}
-      </>
-    </Wrapper>
+    <PostInfoButton onClick={toggle} active={isActive} disabled={loading} count={count} num={num}>
+      {children}
+    </PostInfoButton>
   );
 };
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -6,6 +6,7 @@ import { createStore } from 'redux';
 import App from './App';
 import rootReducer from './modules';
 import { saveState, loadState } from './utils/localStorage';
+import setBodyTheme from './utils/darkmode';
 
 const loadedState = loadState();
 
@@ -18,7 +19,10 @@ const store = createStore(
 store.subscribe(() => {
   saveState({
     user: store.getState().user,
+    post: store.getState().post,
+    theme: store.getState().theme,
   });
+  setBodyTheme(store.getState().theme.isDarkMode);
 });
 
 ReactDOM.render(

--- a/client/src/modules/index.js
+++ b/client/src/modules/index.js
@@ -3,11 +3,15 @@ import { combineReducers } from 'redux';
 import dietColumnContainer from './dietColumnContainer';
 import toast from './toast';
 import user from './user';
+import post from './post';
+import theme from './theme';
 
 const rootReducer = combineReducers({
   dietColumnContainer,
   toast,
   user,
+  post,
+  theme,
 });
 
 export default rootReducer;

--- a/client/src/modules/post.js
+++ b/client/src/modules/post.js
@@ -1,0 +1,35 @@
+//Action Type
+const SET_POST_INFO = 'post/SET_POST_INFO';
+const RESET_POST_INFO = 'post/RESET_POST_INFO';
+
+//Action Creator
+export const setPostInfo = (postType, postId) => ({
+  type: SET_POST_INFO,
+  payload: { postType, postId },
+});
+export const resetPostInfo = () => ({
+  type: RESET_POST_INFO,
+});
+
+//init
+const initialState = {
+  postType: '',
+  postId: '',
+};
+
+//Reducer
+const postReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_POST_INFO:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case RESET_POST_INFO:
+      return initialState;
+    default:
+      return state;
+  }
+};
+
+export default postReducer;

--- a/client/src/modules/theme.js
+++ b/client/src/modules/theme.js
@@ -1,0 +1,24 @@
+//Action Type
+const TOGGLE_THEME = 'theme/TOGGLE_THEME';
+
+//Action Creator
+export const toggleTheme = () => ({ type: TOGGLE_THEME });
+
+//init
+const initialState = {
+  isDarkMode: false,
+};
+
+//Reducer
+const themeReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case TOGGLE_THEME:
+      return {
+        isDarkMode: !state.isDarkMode,
+      };
+    default:
+      return state;
+  }
+};
+
+export default themeReducer;

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -182,13 +182,15 @@ const LandingPage = () => {
           <Circle key={idx} active={idx === useScroll} onClick={() => setUseScroll(idx)} />
         ))}
       </CircleContainer>
-      <ScrollToTop>
-        <HiOutlineArrowCircleUp
-          onClick={() => {
-            page(0);
-          }}
-        />
-      </ScrollToTop>
+      {useScroll > 0 && (
+        <ScrollToTop>
+          <HiOutlineArrowCircleUp
+            onClick={() => {
+              page(0);
+            }}
+          />
+        </ScrollToTop>
+      )}
       <PageScrollerContainer>
         <ReactPageScroller
           className="scroller"

--- a/client/src/pages/RecipeEditPage.js
+++ b/client/src/pages/RecipeEditPage.js
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import axios from 'axios';
@@ -8,6 +9,7 @@ import useToast from '../hooks/toast/useToast';
 import StandardButton from '../components/common/buttons/StandardButton';
 import HashTagEditor from '../components/common/HashtagEditor';
 import extractThumbnailKey from '../utils/thumbnail';
+import { setPostInfo } from '../modules/post';
 
 const { REACT_APP_MOBILE_WIDTH, REACT_APP_WEB_MAX_WIDTH } = process.env;
 
@@ -52,6 +54,7 @@ const RecipeEditPage = () => {
   const [disabled, setDisabled] = useState(false);
   const addMessage = useToast();
   const history = useHistory();
+  const dispatch = useDispatch();
 
   const onClickSave = async () => {
     const title = titleRef.current.value;
@@ -63,6 +66,7 @@ const RecipeEditPage = () => {
       addMessage({ mode: 'info', message: '제목을 입력해주세요', delay: 1000 });
       return;
     }
+
     if (!recipeContent.trim().length) {
       editorInstance.mdEditor.el.childNodes[1].focus();
       addMessage({ mode: 'info', message: '본문을 입력해주세요', delay: 1000 });
@@ -97,11 +101,11 @@ const RecipeEditPage = () => {
         },
       );
       if (status === 201) {
+        dispatch(setPostInfo('recipes', postId));
         addMessage({ message, delay: 1000 }, () => {
-          // save postId to redux
           history.push({
             pathname: '/recipes',
-            state: { postId },
+            search: '?sort=dd',
           });
         });
       } else {

--- a/client/src/styles/GlobalStyles.js
+++ b/client/src/styles/GlobalStyles.js
@@ -13,16 +13,17 @@ const GlobalStyle = createGlobalStyle`
     }
 
     *::-webkit-scrollbar-track {
-        background: #f1f1f1; 
+        background: #e4e4e4;
+        border-radius: 5px; 
     }
 
     *::-webkit-scrollbar-thumb {
-        background: #888;
+        background: #9f9f9f;
         border-radius: 5px;
     }
 
     *::-webkit-scrollbar-thumb:hover {
-        background: #555; 
+        background: #888888;
     }
 `;
 

--- a/client/src/utils/darkmode.js
+++ b/client/src/utils/darkmode.js
@@ -1,0 +1,9 @@
+const setBodyTheme = isDarkMode => {
+  if (isDarkMode) {
+    document.body.style.backgroundColor = '#1F2023';
+  } else {
+    document.body.style.backgroundColor = 'white';
+  }
+};
+
+export default setBodyTheme;


### PR DESCRIPTION
## 작업 내용
- 다크모드 toggler 구현 및 redux로 상태관리
- 포스트 정보 버튼 UI와 logic을 분리
- 카드 컴포넌트에 다크모드 적용 및 페이지 하단에서 부자연스러운 스크롤링 수정
- 레시피 페이지 이동시 디폴트 정렬옵션을 최신순으로 설정
- 레시피 작성 후 레시피 페이지로 이동 후 작성한 게시물 모달을 띄우도록 구현
- 첫 번째 스크롤 페이지에서는 맨 위로 버튼이 나타나지 않도록 수정
- 스크롤바 CSS 수정