### PR TITLE
[Server] Feat/Fix: 특정 유저의  좋아요, 북마크 id 조회 구현 및 댓글 갯수 업데이트 반영

### DIFF
--- a/server/controller/comment/createComment.js
+++ b/server/controller/comment/createComment.js
@@ -49,6 +49,9 @@ module.exports = async (req, res) => {
         comment.save(),
         Recipe.updateOne({ _id: ObjectId(postId) }, { $inc: { commentsCount: 1 } }),
       ]);
+
+      const { commentsCount } = await Recipe.findOne({ _id: ObjectId(postId) });
+      return res.status(201).send({ data: { commentsCount }, message: '댓글이 작성되었습니다.' });
     } else {
       const [user, diet] = await Promise.all([
         User.findById(ObjectId(payload)),
@@ -64,8 +67,10 @@ module.exports = async (req, res) => {
         comment.save(),
         Diet.updateOne({ _id: ObjectId(postId) }, { $inc: { commentsCount: 1 } }),
       ]);
+
+      const { commentsCount } = await Diet.findOne({ _id: ObjectId(postId) });
+      return res.status(201).send({ data: { commentsCount }, message: '댓글이 작성되었습니다.' });
     }
-    return res.status(201).send({ message: '댓글이 작성되었습니다.' });
   } catch (err) {
     return res.status(500).send({ message: err.message });
   }

--- a/server/controller/user/info.js
+++ b/server/controller/user/info.js
@@ -162,4 +162,52 @@ module.exports = {
       return res.status(500).send({ message: err.message });
     }
   },
+  interaction: async (req, res) => {
+    try {
+      let { nickname, postType } = req.params;
+      postType = postType.slice(0, -1);
+      if (!nickname) {
+        return res.status(400).send({ message: '닉네임을 입력받지 않았습니다.' });
+      }
+
+      User.findOne({ nickname }, async (err, user) => {
+        if (err) {
+          return res.status(400).send(err);
+        }
+
+        if (!user) {
+          return res.status(400).send({ message: '존재하지 않는 유저입니다.' });
+        }
+
+        const { subscribes } = user;
+
+        const [likes, bookmarks] = await Promise.all([
+          Like.find({ user: user._id }),
+          Bookmark.find({ user: user._id }),
+        ]);
+
+        console.log(likes, bookmarks);
+
+        const likeIds = await Promise.all(
+          likes.map(async like => {
+            if (like.postType === postType) {
+              return like.post;
+            }
+          }),
+        );
+
+        const bookmarkIds = await Promise.all(
+          bookmarks.map(async bookmark => {
+            if (bookmark.postType === postType) {
+              return bookmark.post;
+            }
+          }),
+        );
+
+        return res.status(200).send({ likeIds, bookmarkIds, subscribes });
+      });
+    } catch (err) {
+      return res.status(500).send({ message: err.message });
+    }
+  },
 };

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -13,6 +13,8 @@ userRouter.delete('/', checkToken, userController.deleteAccount);
 
 userRouter.get('/:nickname', userController.info.get);
 
+userRouter.get('/:nickname/interaction/:postType', userController.info.interaction);
+
 userRouter.patch('/', checkToken, userController.info.patch);
 
 userRouter.post('/subscribe/:nickname', checkToken, userController.subscribe);


### PR DESCRIPTION
## 특정 유저의 좋아요, 북마크를 한 게시물의 id 조회 부분
- users/:nickname/interaction/:postType 라우터 구현
- 해당 유저의 레시피/식단 게시물에 대한 좋아요, 북마크, 구독한 유저에 대한 고유 id를 받아올 수 있게 하였음
![Screenshot_from_2021-10-06_10-54-44](https://user-images.githubusercontent.com/68040092/136132322-1047f18f-f558-4afe-a9ca-1cf5ccca2d00.png)


## 댓글 갯수 업데이트 반영 부분
- 댓글 작성 시, 총 댓글 갯수 업데이트를 위해 응답에 해당 게시물의 댓글 갯수를 담아서 보냄
![Screenshot from 2021-10-06 11-37-48](https://user-images.githubusercontent.com/68040092/136132285-2d44459c-a1fa-413a-bcd2-fe3f37d8bc1d.png)

