### PR TITLE
[Client] Fix: 썸네일 이미지 등록 관련 문제 해결

### DIFF
--- a/client/src/components/SlotMachine.js
+++ b/client/src/components/SlotMachine.js
@@ -159,13 +159,13 @@ const SlotMachine = ({ rollingProps }) => {
       0: '갈비찜',
       1: '김치찜',
       2: '김치찌개',
-      3: '삼겹살',
+      3: '부추전',
       4: '된장찌개',
       5: '마라탕',
       6: '간장새우',
       7: '찜닭',
-      8: '피자',
-      9: '햄버거',
+      8: '크림파스타',
+      9: '당근케이크',
     };
     let randomNumber = Math.floor(Math.random() * 10);
     setNumber(list[randomNumber]);

--- a/client/src/components/header/RightContainer.js
+++ b/client/src/components/header/RightContainer.js
@@ -47,6 +47,9 @@ const UserMenuContainer = styled.div`
       color: black;
     }
   }
+  .userInfo {
+    cursor: pointer;
+  }
 `;
 
 const WriteContainer = styled.div`

--- a/client/src/components/recipe_edit/RecipeEditor.js
+++ b/client/src/components/recipe_edit/RecipeEditor.js
@@ -38,7 +38,7 @@ const RecipeEditor = ({ editorRef, setImages }) => {
     <>
       <Editor
         previewStyle="vertical"
-        height="600px"
+        height="550px"
         initialEditType="markdown"
         plugins={[[colorSyntax]]}
         ref={editorRef}

--- a/client/src/pages/DietEditPage.js
+++ b/client/src/pages/DietEditPage.js
@@ -54,7 +54,7 @@ const DietEditPageStyle = styled.div`
 
   > .button-box {
     display: flex;
-    justify-content: right;
+    justify-content: flex-end;
     margin-top: 10px;
 
     button:last-child {

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -105,6 +105,9 @@ const Section1 = styled.section`
     .logo {
       margin-right: 2em;
       width: 250px;
+      &:hover {
+        cursor: pointer;
+      }
     }
     .reverse {
       transform: rotate(90deg);

--- a/server/controller/recipe/createPost.js
+++ b/server/controller/recipe/createPost.js
@@ -19,15 +19,14 @@ module.exports = async (req, res) => {
     }
 
     const user = await User.findById(ObjectId(payload));
-    const { title, content, images = [], hashtags = [] } = req.body;
+    const { title, content, thumbnail_url, hashtags = [] } = req.body;
 
     const post = new Recipe({
       title,
       content,
       user,
       hashtags,
-      thumbnail_url: images.length ? images[0].imageKey : null,
-      originalFileName: images.length ? images[0].originalname : null,
+      thumbnail_url,
     });
 
     await post.save();

--- a/server/controller/recipe/updatePost.js
+++ b/server/controller/recipe/updatePost.js
@@ -33,15 +33,15 @@ module.exports = async (req, res) => {
     const {
       title = recipe.title,
       content = recipe.content,
-      images = [],
+      thumbnail_url = recipe.thumbnail_url,
       hashtags = recipe.hashtags,
     } = req.body;
 
     recipe.title = title;
     recipe.content = content;
     recipe.hashtags = hashtags;
-    recipe.thumbnail_url = images.length ? images[0].imageKey : null;
-    recipe.originalFileName = images.length ? images[0].originalname : null;
+    recipe.thumbnail_url = thumbnail_url;
+    recipe.originalFileName = null;
 
     await recipe.save();
     return res.status(200).send({ data: { postId: id }, message: '해당 레시피를 수정하였습니다.' });


### PR DESCRIPTION
## 오류 원인
- 간단한 텍스트와 이미지 여러장을 에디터에 작성한 후 등록할 경우는 문제가 없었지만
- 에디터에서 제공하는 다양한 마크다운 기능들이 적용될 때 이미지를 추출하는 정규식이 오작동하게 되어
- 서버로 정상적인 thumbnail_url을 보낼 수 없게 되었다.
- 레시피 수정의 경우, 레시피 작성때와 달리 에디터상에서 이미지 객체를 갖고 있지 않기때문에 서버로 보낼 이미지 데이터가 없어서 본문은 수정되어도 섬네일 이미지 수정이 불가능

## 해결 방안
- 여러장의 사진에서 가장 처음 사진의 src를 추출하는 일은 어렵지만 정규식을 수정한다면 해결할 수 있는 가능성도 O
- 레시피 수정모드에서는 에디터상에서 이미지 객체를 관리하고 있는 상태가 아니므로 서버에 제대로된 data를 전달할 수 없기 때문에
- 사용자 입장에서 조금 번거로울 수 있지만, 직접 이미지 태그 내의 src를 복사/붙여넣기 하여 서버로 전달하는 것이 현재로서는 가장 효과적인 해결방법이라고 생각
- 약간의 장점이라고 한다면, 섬네일 사진을 자유롭게 정할 수 있기 때문에 레시피 최상단에 완성된 음식을 배치해야하는 의무가 사라짐
