### PR TITLE
[Server] Fix: 쿠키 로컬/배포 옵션 설정 간편화

### DIFF
--- a/server/controller/user/signin.js
+++ b/server/controller/user/signin.js
@@ -35,15 +35,15 @@ module.exports = (req, res) => {
 
         res.cookie('accessToken', accessToken, {
           httpOnly: true,
-          secure: true,
-          sameSite: 'None',
-          domain: '.menuger.shop',
+          ...(process.env.COOKIE_SECURE === 'true'
+            ? { secure: true, sameSite: 'None', domain: '.menuger.shop' }
+            : null),
         });
         res.cookie('refreshToken', refreshToken, {
           httpOnly: true,
-          secure: true,
-          sameSite: 'None',
-          domain: '.menuger.shop',
+          ...(process.env.COOKIE_SECURE === 'true'
+            ? { secure: true, sameSite: 'None', domain: '.menuger.shop' }
+            : null),
         });
 
         user.refreshToken = refreshToken;

--- a/server/controller/user/signinKakao.js
+++ b/server/controller/user/signinKakao.js
@@ -68,31 +68,31 @@ module.exports = async (req, res) => {
 
     res.cookie('kakao_login', 'success', {
       maxAge,
-      domain: '.menuger.shop',
+      ...(process.env.COOKIE_SECURE === 'true' ? { domain: '.menuger.shop' } : null),
     });
     res.cookie('email', email, {
       maxAge,
-      domain: '.menuger.shop',
+      ...(process.env.COOKIE_SECURE === 'true' ? { domain: '.menuger.shop' } : null),
     });
     res.cookie('nickname', nickname, {
       maxAge,
-      domain: '.menuger.shop',
+      ...(process.env.COOKIE_SECURE === 'true' ? { domain: '.menuger.shop' } : null),
     });
     res.cookie('image_url', image_url, {
       maxAge,
-      domain: '.menuger.shop',
+      ...(process.env.COOKIE_SECURE === 'true' ? { domain: '.menuger.shop' } : null),
     });
     res.cookie('kakaoAccessToken', data.access_token, {
       httpOnly: true,
-      secure: true,
-      sameSite: 'None',
-      domain: '.menuger.shop',
+      ...(process.env.COOKIE_SECURE === 'true'
+        ? { secure: true, sameSite: 'None', domain: '.menuger.shop' }
+        : null),
     });
     res.cookie('kakaoRefreshToken', data.refresh_token, {
       httpOnly: true,
-      secure: true,
-      sameSite: 'None',
-      domain: '.menuger.shop',
+      ...(process.env.COOKIE_SECURE === 'true'
+        ? { secure: true, sameSite: 'None', domain: '.menuger.shop' }
+        : null),
     });
     res.clearCookie('accessToken').clearCookie('refreshToken');
     res.redirect(process.env.SITE_DOMAIN);

--- a/server/controller/user/signout.js
+++ b/server/controller/user/signout.js
@@ -34,10 +34,18 @@ module.exports = async (req, res) => {
       }
 
       return res
-        .clearCookie('accessToken', { path: '/', domain: '.menuger.shop' })
-        .clearCookie('refreshToken', { path: '/', domain: '.menuger.shop' })
-        .clearCookie('kakaoAccessToken', { path: '/', domain: '.menuger.shop' })
-        .clearCookie('kakaoRefreshToken', { path: '/', domain: '.menuger.shop' })
+        .clearCookie('accessToken', {
+          ...(process.env.COOKIE_SECURE === 'true' ? { path: '/', domain: '.menuger.shop' } : null),
+        })
+        .clearCookie('refreshToken', {
+          ...(process.env.COOKIE_SECURE === 'true' ? { path: '/', domain: '.menuger.shop' } : null),
+        })
+        .clearCookie('kakaoAccessToken', {
+          ...(process.env.COOKIE_SECURE === 'true' ? { path: '/', domain: '.menuger.shop' } : null),
+        })
+        .clearCookie('kakaoRefreshToken', {
+          ...(process.env.COOKIE_SECURE === 'true' ? { path: '/', domain: '.menuger.shop' } : null),
+        })
         .status(200)
         .send({ message: '로그아웃 하였습니다.' });
     });

--- a/server/controller/utils/checktoken.js
+++ b/server/controller/utils/checktoken.js
@@ -55,18 +55,18 @@ module.exports = {
 
             res.cookie('kakaoAccessToken', access_token, {
               httpOnly: true,
-              secure: true,
-              sameSite: 'None',
-              domain: '.menuger.shop',
+              ...(process.env.COOKIE_SECURE === 'true'
+                ? { secure: true, sameSite: 'None', domain: '.menuger.shop' }
+                : null),
             });
             req.cookies.kakaoAccessToken = access_token;
 
             if (refresh_token !== null) {
               res.cookie('kakaoRefreshToken', refresh_token, {
                 httpOnly: true,
-                secure: true,
-                sameSite: 'None',
-                domain: '.menuger.shop',
+                ...(process.env.COOKIE_SECURE === 'true'
+                  ? { secure: true, sameSite: 'None', domain: '.menuger.shop' }
+                  : null),
               });
               req.cookies.kakaoRefreshToken = refresh_token;
               user.refreshToken = refresh_token;
@@ -102,9 +102,9 @@ module.exports = {
               const newAccessToken = createAccessToken(user._id.toHexString());
               res.cookie('accessToken', newAccessToken, {
                 httpOnly: true,
-                secure: true,
-                sameSite: 'None',
-                domain: '.menuger.shop',
+                ...(process.env.COOKIE_SECURE === 'true'
+                  ? { secure: true, sameSite: 'None', domain: '.menuger.shop' }
+                  : null),
               });
               req.cookies.accessToken = newAccessToken;
               next();
@@ -124,9 +124,9 @@ module.exports = {
               const newRefreshToken = createRefreshToken({});
               res.cookie('refreshToken', newRefreshToken, {
                 httpOnly: true,
-                secure: true,
-                sameSite: 'None',
-                domain: '.menuger.shop',
+                ...(process.env.COOKIE_SECURE === 'true'
+                  ? { secure: true, sameSite: 'None', domain: '.menuger.shop' }
+                  : null),
               });
               req.cookies.refreshToken = newRefreshToken;
 


### PR DESCRIPTION
## Cookie 옵션 설정 부분
- Spread Syntax를 사용하여 환경변수에 값에 따라 로컬용으로할지, 배포용으로 할지 정할 수 있게 구성하였음.